### PR TITLE
Re-register node if detected unregistered during the healthcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ dep_rabbitmq_aws = git https://github.com/gmr/rabbitmq-aws.git 0.1.3
 
 ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
 ERLANG_MK_COMMIT = rabbitmq-tmp
-BUILD_DEPS+= ranch
+BUILD_DEPS+= rabbit ranch
 current_rmq_ref = stable
 
 include rabbitmq-components.mk


### PR DESCRIPTION
Fixes https://github.com/aweber/rabbitmq-autocluster/issues/116
