### PR TITLE
Add consul_deregister_after parameter

### DIFF
--- a/include/autocluster.hrl
+++ b/include/autocluster.hrl
@@ -37,7 +37,7 @@
          {config, consul_svc_addr_nic,   "CONSUL_SVC_ADDR_NIC",    "undefined",  string,  false},
          {config, consul_svc_port,       "CONSUL_SVC_PORT",        5672,         integer, true},
          {config, consul_svc_ttl,        "CONSUL_SVC_TTL",         30,           integer, false},
-         {config, consul_deregister_after, "CONSUL_DEREGISTER_AFTER", undefined, atom,    false}, %% consul deregister_critical_service_after
+         {config, consul_deregister_after, "CONSUL_DEREGISTER_AFTER", "",        integer,    false}, %% consul deregister_critical_service_after
 
          {config, autocluster_host,      "AUTOCLUSTER_HOST",       "undefined",  string,  false}, %% DNS
 

--- a/include/autocluster.hrl
+++ b/include/autocluster.hrl
@@ -37,6 +37,7 @@
          {config, consul_svc_addr_nic,   "CONSUL_SVC_ADDR_NIC",    "undefined",  string,  false},
          {config, consul_svc_port,       "CONSUL_SVC_PORT",        5672,         integer, true},
          {config, consul_svc_ttl,        "CONSUL_SVC_TTL",         30,           integer, false},
+         {config, consul_deregister_after, "CONSUL_DEREGISTER_AFTER", undefined, atom,    false}, %% consul deregister_critical_service_after
 
          {config, autocluster_host,      "AUTOCLUSTER_HOST",       "undefined",  string,  false}, %% DNS
 

--- a/src/autocluster_consul.erl
+++ b/src/autocluster_consul.erl
@@ -365,11 +365,19 @@ registration_body_maybe_add_check(Payload) ->
 -spec registration_body_maybe_add_check(Payload :: list(),
                                         TTL :: integer() | undefined)
     -> list().
-registration_body_maybe_add_check(Payload, undefined) -> Payload;
+registration_body_maybe_add_check(Payload, undefined) ->
+    case registration_body_maybe_add_deregister([]) of
+        [{'Deregister_critical_service_after', Value}]->
+            Check = [{'Check', [{'Deregister_critical_service_after', Value}]}],
+            lists:append(Payload, Check);
+        _ -> Payload
+    end;
 registration_body_maybe_add_check(Payload, TTL) ->
-  Check = [{'Check', [{'Notes', list_to_atom(?CONSUL_CHECK_NOTES)},
-                      {'TTL', list_to_atom(service_ttl(TTL))}]}],
-  lists:append(Payload, Check).
+    CheckItems = [{'Notes', list_to_atom(?CONSUL_CHECK_NOTES)},
+        {'TTL', list_to_atom(service_ttl(TTL))}],
+    Check = [{'Check', registration_body_maybe_add_deregister(CheckItems)}],
+    lists:append(Payload, Check).
+
 
 
 %%--------------------------------------------------------------------
@@ -384,6 +392,38 @@ registration_body_add_port(Payload) ->
                [{'Port', autocluster_config:get(consul_svc_port)}]).
 
 
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Evaluate the configured value for the deregister_critical_service_after.
+%% Consul removes the node after the timeout (If it is set)
+%% Check definition if it is set.
+%%
+%% @end
+%%--------------------------------------------------------------------
+
+registration_body_maybe_add_deregister(Payload) ->
+    Deregister = autocluster_config:get(consul_deregister_after),
+    registration_body_maybe_add_deregister(Payload, Deregister).
+
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Evaluate the configured value for the deregister_critical_service_after.
+%% Consul removes the node after the timeout (If it is set)
+%% Check definition if it is set.
+%% @end
+%%--------------------------------------------------------------------
+
+-spec registration_body_maybe_add_deregister(Payload :: list(),
+    TTL :: integer() | undefined)
+        -> list().
+registration_body_maybe_add_deregister(Payload, undefined) -> Payload;
+registration_body_maybe_add_deregister(Payload, Deregister_After) ->
+    Deregister = {'Deregister_critical_service_after',
+        list_to_atom(service_ttl(Deregister_After))},
+    [Deregister | Payload].
 %%--------------------------------------------------------------------
 %% @private
 %% @doc

--- a/src/autocluster_consul.erl
+++ b/src/autocluster_consul.erl
@@ -367,9 +367,11 @@ registration_body_maybe_add_check(Payload) ->
     -> list().
 registration_body_maybe_add_check(Payload, undefined) ->
     case registration_body_maybe_add_deregister([]) of
-        [{'Deregister_critical_service_after', Value}]->
-            Check = [{'Check', [{'Deregister_critical_service_after', Value}]}],
-            lists:append(Payload, Check);
+        [{'Deregister_critical_service_after', _}]->
+            autocluster_log:warning("Can't use Consul Deregister After without " ++
+            "using TTL. The parameter CONSUL_DEREGISTER_AFTER will be ignored"),
+            Payload;
+
         _ -> Payload
     end;
 registration_body_maybe_add_check(Payload, TTL) ->
@@ -423,7 +425,7 @@ registration_body_maybe_add_deregister(Payload, undefined) -> Payload;
 registration_body_maybe_add_deregister(Payload, Deregister_After) ->
     Deregister = {'Deregister_critical_service_after',
         list_to_atom(service_ttl(Deregister_After))},
-    [Deregister | Payload].
+    Payload ++ [Deregister].
 %%--------------------------------------------------------------------
 %% @private
 %% @doc

--- a/test/src/autocluster_consul_tests.erl
+++ b/test/src/autocluster_consul_tests.erl
@@ -79,11 +79,21 @@ build_registration_body_test_() ->
                          {'TTL','30s'}]}],
         ?assertEqual(Expectation, autocluster_consul:build_registration_body())
        end},
-      {"with addr set", fun() ->
+      {"with ttl set", fun() ->
         os:putenv("CONSUL_SVC_TTL", ""),
         Expectation = [{'ID','rabbitmq'},
                        {'Name',rabbitmq},
                        {'Port',5672}],
+        ?assertEqual(Expectation, autocluster_consul:build_registration_body())
+      end},
+      {"with deregister set", fun() ->
+        os:putenv("CONSUL_DEREGISTER_AFTER", 257),
+        Expectation = [{'ID','rabbitmq'},
+          {'Name',rabbitmq},
+          {'Port',5672},
+          {'Check',
+            [{'Deregister_critical_service_after','257s'}]}],
+
         ?assertEqual(Expectation, autocluster_consul:build_registration_body())
       end}
     ]

--- a/test/src/autocluster_consul_tests.erl
+++ b/test/src/autocluster_consul_tests.erl
@@ -87,13 +87,32 @@ build_registration_body_test_() ->
         ?assertEqual(Expectation, autocluster_consul:build_registration_body())
       end},
       {"with deregister set", fun() ->
-        os:putenv("CONSUL_DEREGISTER_AFTER", 257),
+        os:putenv("CONSUL_DEREGISTER_AFTER", "257"),
         Expectation = [{'ID','rabbitmq'},
           {'Name',rabbitmq},
           {'Port',5672},
           {'Check',
-            [{'Deregister_critical_service_after','257s'}]}],
-
+            [{'Notes','RabbitMQ Auto-Cluster Plugin TTL Check'},
+              {'TTL','30s'},
+              {'Deregister_critical_service_after','257s'}]}],
+        ?assertEqual(Expectation, autocluster_consul:build_registration_body())
+      end},
+      {"with unset deregister and ttl set", fun() ->
+        os:putenv("CONSUL_DEREGISTER_AFTER", ""),
+        os:putenv("CONSUL_SVC_TTL", ""),
+        Expectation = [{'ID','rabbitmq'},
+          {'Name',rabbitmq},
+          {'Port',5672}],
+        ?assertEqual(Expectation, autocluster_consul:build_registration_body())
+      end},
+      %% CONSUL_DEREGISTER_AFTER has be ignored because can't be triggered
+      %% without using TTL
+      {"with set only deregister set", fun() ->
+        os:putenv("CONSUL_SVC_TTL", ""),
+        os:putenv("CONSUL_DEREGISTER_AFTER", "123"),
+        Expectation = [{'ID','rabbitmq'},
+          {'Name',rabbitmq},
+          {'Port',5672}],
         ?assertEqual(Expectation, autocluster_consul:build_registration_body())
       end}
     ]


### PR DESCRIPTION
Fixes https://github.com/aweber/rabbitmq-autocluster/issues/136

`consul_deregister_after` is a wrapper for the consul command [`deregister_critical_service_after` ](https://www.consul.io/docs/agent/checks.html)

Param values:

- `consul_deregister_after` ( config file )
- `CONSUL_DEREGISTER_AFTER` ( Environment variable )

Default value: "" = `undefined`

How to test it:
1.
```
CONSUL_DEREGISTER_AFTER=60  CONSUL_SVC_ADDR_AUTO=true AUTOCLUSTER_TYPE=consul  CONSUL_HOST=localhost  gmake run-broker
```
2.
Check the RabbitMQ registration on Consul:
```
curl http://localhost:8500/v1/catalog/service/rabbitmq | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   337  100   337    0     0  57128      0 --:--:-- --:--:-- --:--:-- 67400
[
    {
        "Address": "10.100.1.68",
        "CreateIndex": 9,
        "ID": "0434e5f3-9e3a-3cc2-97ac-46b0c312a783",
        "ModifyIndex": 9,
        "Node": "mac",
        "NodeMeta": {},
        "ServiceAddress": "mac",
        "ServiceEnableTagOverride": false,
        "ServiceID": "rabbitmq:mac",
        "ServiceName": "rabbitmq",
        "ServicePort": 5672,
        "ServiceTags": [],
        "TaggedAddresses": {
            "lan": "10.100.1.68",
            "wan": "10.100.1.68"
        }
    }
]
```
3. stop the node, after ~ 30s you will see:

```
2017/03/16 13:45:39 [WARN] agent: Check 'service:rabbitmq:mac' missed TTL, is now critical
2017/03/16 13:45:39 [INFO] agent: Synced check 'service:rabbitmq:mac'
```

and after ~60 seconds you will see:

```
2017/03/16 13:47:01 [INFO] agent: Check "service:rabbitmq:mac" for service "rabbitmq:mac" has been critical for too long; deregistered service
 2017/03/16 13:47:01 [INFO] agent: Deregistered check 'service:rabbitmq:mac'
```

and the service is removed from consul

```
curl http://localhost:8500/v1/catalog/service/rabbitmq                      
[]%  
```


Note: I put [this log](https://github.com/rabbitmq/rabbitmq-autocluster/compare/stable...rabbitmq:rabbitmq-autocluster-aweber-136?expand=1#diff-3d9d8de61282c4e02ab990a370f0a37cR371) because (for my side) does not make sense to enable the `deregister_critical_service_after` param without `TTL`

 

 