### PR TITLE
Support hostname from nodename in consul using CONSUL_SVC_ADDR_NODENAME

### DIFF
--- a/include/autocluster.hrl
+++ b/include/autocluster.hrl
@@ -35,6 +35,7 @@
          {config, consul_svc_addr,       "CONSUL_SVC_ADDR",        "undefined",  string,  false},
          {config, consul_svc_addr_auto,  "CONSUL_SVC_ADDR_AUTO",   false,        atom,    false},
          {config, consul_svc_addr_nic,   "CONSUL_SVC_ADDR_NIC",    "undefined",  string,  false},
+         {config, consul_svc_addr_nodename,   "CONSUL_SVC_ADDR_NODENAME",    false,  atom,  false},
          {config, consul_svc_port,       "CONSUL_SVC_PORT",        5672,         integer, true},
          {config, consul_svc_ttl,        "CONSUL_SVC_TTL",         30,           integer, false},
          {config, consul_deregister_after, "CONSUL_DEREGISTER_AFTER", "",        integer,    false}, %% consul deregister_critical_service_after

--- a/src/autocluster_consul.erl
+++ b/src/autocluster_consul.erl
@@ -454,6 +454,25 @@ registration_body_maybe_add_tag(Payload, Cluster) ->
   lists:append(Payload, [{'Tags', [list_to_atom(Cluster)]}]).
 
 
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Validate CONSUL_SVC_ADDR_NODENAME parameter
+%% it can be used if CONSUL_SVC_ADDR_AUTO is true
+%% @end
+%%--------------------------------------------------------------------
+
+-spec validate_addr_parameters(false | true, false | true) -> false | true.
+validate_addr_parameters(false, true) ->
+    autocluster_log:warning("The params CONSUL_SVC_ADDR_NODENAME" ++
+				" can be used only if CONSUL_SVC_ADDR_AUTO is true." ++
+				" CONSUL_SVC_ADDR_NODENAME value will be ignored."),
+    false;
+validate_addr_parameters(_, _) ->
+    true.
+
+
 %%--------------------------------------------------------------------
 %% @private
 %% @doc
@@ -463,6 +482,8 @@ registration_body_maybe_add_tag(Payload, Cluster) ->
 %%--------------------------------------------------------------------
 -spec service_address() -> string().
 service_address() ->
+  validate_addr_parameters(autocluster_config:get(consul_svc_addr_auto),
+      autocluster_config:get(consul_svc_addr_nodename)),
   service_address(autocluster_config:get(consul_svc_addr),
                   autocluster_config:get(consul_svc_addr_auto),
                   autocluster_config:get(consul_svc_addr_nic),

--- a/src/autocluster_consul.erl
+++ b/src/autocluster_consul.erl
@@ -465,7 +465,8 @@ registration_body_maybe_add_tag(Payload, Cluster) ->
 service_address() ->
   service_address(autocluster_config:get(consul_svc_addr),
                   autocluster_config:get(consul_svc_addr_auto),
-                  autocluster_config:get(consul_svc_addr_nic)).
+                  autocluster_config:get(consul_svc_addr_nic),
+                  autocluster_config:get(consul_svc_addr_nodename)).
 
 
 %%--------------------------------------------------------------------
@@ -480,12 +481,13 @@ service_address() ->
 %%--------------------------------------------------------------------
 -spec service_address(Static :: string(),
                       Auto :: boolean(),
-                      AutoNIC :: string()) -> string().
-service_address(_, true, "undefined") ->
-  autocluster_util:node_hostname();
-service_address(Value, false, "undefined") ->
+                      AutoNIC :: string(),
+                      FromNodename :: boolean()) -> string().
+service_address(_, true, "undefined", FromNodename) ->
+  autocluster_util:node_hostname(FromNodename);
+service_address(Value, false, "undefined", _) ->
   Value;
-service_address(_, false, NIC) ->
+service_address(_, false, NIC, _) ->
   {ok, Addr} = autocluster_util:nic_ipv4(NIC),
   Addr.
 

--- a/src/autocluster_util.erl
+++ b/src/autocluster_util.erl
@@ -11,7 +11,7 @@
          as_string/1,
          backend_module/0,
          nic_ipv4/1,
-         node_hostname/0,
+         node_hostname/1,
          node_name/1,
          parse_port/1]).
 
@@ -155,13 +155,17 @@ nic_ipv4_address([_|T]) ->
 %%--------------------------------------------------------------------
 %% @doc
 %% Return the hostname for the current node (without the tuple)
+%% Hostname can be taken from network info or nodename.
 %% @end
 %%--------------------------------------------------------------------
--spec node_hostname() -> string().
-node_hostname() ->
-  {ok, Hostname} = inet:gethostname(),
-  Hostname.
-
+-spec node_hostname(boolean()) -> string().
+node_hostname(false = _FromNodename) ->
+    {ok, Hostname} = inet:gethostname(),
+    Hostname;
+node_hostname(true = _FromNodename) ->
+    {match, [Hostname]} = re:run(atom_to_list(node()), "@(.*)",
+                                 [{capture, [1], list}]),
+    Hostname.
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/test/src/autocluster_util_tests.erl
+++ b/test/src/autocluster_util_tests.erl
@@ -178,10 +178,12 @@ node_hostname_test_() ->
     end,
     fun autocluster_testing:on_finish/1,
     [
+     %% Hostname from nodename cannot be tested as mocking the 'erlang' module
+     %% causes the test process to hang.
       {
-        "value", fun() ->
+        "hostname from network", fun() ->
           meck:expect(inet, gethostname, fun() -> {ok, "hal4500"} end),
-          ?assertEqual("hal4500", autocluster_util:node_hostname())
+          ?assertEqual("hal4500", autocluster_util:node_hostname(false))
         end
       }
     ]


### PR DESCRIPTION
Adresses user request to select the long nodename given instead of
retrieving it from inets.

[#141944663]
aweber/rabbitmq-autocluster#62