### PR TITLE
Read AWS_EC2_TAGS from environment variables

### DIFF
--- a/include/autocluster.hrl
+++ b/include/autocluster.hrl
@@ -20,7 +20,7 @@
          {config, node_type,             "RABBITMQ_NODE_TYPE",     disc,         atom,    false},
 
          {config, aws_autoscaling,       "AWS_AUTOSCALING",        false,        atom,    false}, %% AWS
-         {config, aws_ec2_tags,          "AWS_EC2_TAGS",           "undefined",  string,  false},
+         {config, aws_ec2_tags,          "AWS_EC2_TAGS",           "undefined",  proplist,  false},
          {config, aws_access_key,        "AWS_ACCESS_KEY_ID",      "undefined",  string,  false},
          {config, aws_secret_key,        "AWS_SECRET_ACCESS_KEY",  "undefined",  string,  false},
          {config, aws_ec2_region,        "AWS_DEFAULT_REGION",     "undefined",  string,  false},

--- a/src/autocluster_config.erl
+++ b/src/autocluster_config.erl
@@ -122,4 +122,6 @@ normalize(Config, Value) when Config#config.type =:= atom ->
 normalize(Config, Value) when Config#config.type =:= integer ->
   autocluster_util:as_integer(Value);
 normalize(Config, Value) when Config#config.type =:= string ->
-  autocluster_util:as_string(Value).
+  autocluster_util:as_string(Value);
+normalize(Config, Value) when Config#config.type =:= proplist ->
+  autocluster_util:as_proplist(Value).

--- a/src/autocluster_util.erl
+++ b/src/autocluster_util.erl
@@ -13,7 +13,9 @@
          nic_ipv4/1,
          node_hostname/1,
          node_name/1,
-         parse_port/1]).
+         parse_port/1,
+         as_proplist/1
+        ]).
 
 
 %% Export all for unit tests
@@ -258,3 +260,18 @@ node_prefix() ->
 parse_port(Value) when is_list(Value) ->
   as_integer(lists:last(string:tokens(Value, ":")));
 parse_port(Value) -> as_integer(Value).
+
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Returns a proplist from a JSON structure (environment variable) or
+%% the settings key (already a proplist).
+%% @end
+%%--------------------------------------------------------------------
+-spec as_proplist(Value :: string() | [{string(), string()}]) ->
+                         [{string(), string()}].
+as_proplist([Tuple | _] = Json) when is_tuple(Tuple) ->
+    Json;
+as_proplist(List) when is_list(List) ->
+    {ok, Json} = rabbit_misc:json_decode(List),
+    [{binary_to_list(K), binary_to_list(V)} || {K, V} <- rabbit_misc:json_to_term(Json)].

--- a/test/src/autocluster_config_tests.erl
+++ b/test/src/autocluster_config_tests.erl
@@ -98,6 +98,15 @@ os_envvar_test_() ->
           os:putenv("CONSUL_PORT", "tcp://172.17.10.3:8501"),
           ?assertEqual(8501, autocluster_config:get(consul_port))
         end
+      },
+      {
+        "aws tags",
+        fun() ->
+          os:putenv("AWS_EC2_TAGS",
+                    "{\"region\": \"us-west-2\",\"service\": \"rabbitmq\"}"),
+          ?assertEqual([{"region", "us-west-2"}, {"service", "rabbitmq"}],
+                       autocluster_config:get(aws_ec2_tags))
+        end
       }
     ]
   }.


### PR DESCRIPTION
Previous implementation did not parse the input, thus it could never use the config provided on the env.

Fixes https://github.com/aweber/rabbitmq-autocluster/issues/117
[#142504601]