### PR TITLE
Depend on rabbitmq-aws from rabbitmq repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
 NO_AUTOPATCH += rabbitmq_aws
 
-dep_rabbitmq_aws = git https://github.com/gmr/rabbitmq-aws.git 0.1.3
+dep_rabbitmq_aws = git https://github.com/rabbitmq/rabbitmq-aws.git stable
 
 # FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
 # reviewed and merged.


### PR DESCRIPTION
Fix for https://github.com/aweber/rabbitmq-autocluster/issues/124 required to fork
Depending on stable until a new tag

[#142676591]