### PR TITLE
Use a non-prefixed service ID in Consul backend's unregister/0

### DIFF
--- a/src/autocluster_consul.erl
+++ b/src/autocluster_consul.erl
@@ -157,7 +157,7 @@ wait_nodelist(N) ->
 %%--------------------------------------------------------------------
 -spec unregister() -> ok | {error, Reason :: string()}.
 unregister() ->
-  Service = string:join(["service", service_id()], ":"),
+  Service = service_id(),
   case autocluster_httpc:get(autocluster_config:get(consul_scheme),
                              autocluster_config:get(consul_host),
                              autocluster_config:get(consul_port),

--- a/test/src/autocluster_consul_tests.erl
+++ b/test/src/autocluster_consul_tests.erl
@@ -586,7 +586,7 @@ unregister_test_() ->
             ?assertEqual("http", Scheme),
             ?assertEqual("localhost", Host),
             ?assertEqual(8500, Port),
-            ?assertEqual([v1, agent, service, deregister, "service:rabbitmq"], Path),
+            ?assertEqual([v1, agent, service, deregister, "rabbitmq"], Path),
             ?assertEqual([], Args),
             {ok, []}
           end),
@@ -599,7 +599,7 @@ unregister_test_() ->
             ?assertEqual("https", Scheme),
             ?assertEqual("consul.service.consul", Host),
             ?assertEqual(8501, Port),
-            ?assertEqual([v1, agent, service, deregister,"service:rabbit:10.0.0.1"], Path),
+            ?assertEqual([v1, agent, service, deregister,"rabbit:10.0.0.1"], Path),
             ?assertEqual([], Args),
             {ok, []}
           end),
@@ -618,7 +618,7 @@ unregister_test_() ->
             ?assertEqual("http", Scheme),
             ?assertEqual("consul.service.consul", Host),
             ?assertEqual(8500, Port),
-            ?assertEqual([v1, agent, service, deregister,"service:rabbitmq"], Path),
+            ?assertEqual([v1, agent, service, deregister,"rabbitmq"], Path),
             ?assertEqual([{token, "token-value"}], Args),
             {ok, []}
           end),


### PR DESCRIPTION
Fixes #18.