### PR TITLE
Consul: added startup locking support

### DIFF
--- a/include/autocluster.hrl
+++ b/include/autocluster.hrl
@@ -34,6 +34,7 @@
          {config, consul_scheme,         "CONSUL_SCHEME",          "http",       string,  false},
          {config, consul_host,           "CONSUL_HOST",            "localhost",  string,  false},
          {config, consul_port,           "CONSUL_PORT",            8500,         integer, true},
+         {config, consul_lock_prefix,    "CONSUL_LOCK_PREFIX",     "rabbitmq",   string,  false},
          {config, consul_domain,         "CONSUL_DOMAIN",          "consul",     string,  false},
          {config, consul_svc,            "CONSUL_SVC",             "rabbitmq",   string,  false},
          {config, consul_svc_addr,       "CONSUL_SVC_ADDR",        "undefined",  string,  false},

--- a/src/autocluster_consul.erl
+++ b/src/autocluster_consul.erl
@@ -62,7 +62,7 @@ lock(Who) ->
             EndTime = Now + autocluster_config:get(lock_wait_time),
             lock(SessionId, Now, EndTime);
         {error, Reason} ->
-           lists:flatten(io_lib:format("Error while creating a session, reason: ~w", [Reason]))
+           lists:flatten(io_lib:format("Error while creating a session, reason: ~s", [Reason]))
     end.
 
 
@@ -78,7 +78,7 @@ unlock(SessionId) ->
         {ok, true} ->
             ok;
         {ok, false} ->
-            {error, lists:flatten(io_lib:format("Error while releasing the lock, session ~w may have been invalidated", [SessionId]))};
+            {error, lists:flatten(io_lib:format("Error while releasing the lock, session ~s may have been invalidated", [SessionId]))};
         {error, _} = Err ->
             Err
     end.
@@ -135,13 +135,13 @@ lock(SessionId, _, EndTime) ->
                         ok ->
                             lock(SessionId, time_compat:erlang_system_time(seconds), EndTime);
                         {error, Reason} ->
-                            {error, lists:flatten(io_lib:format("Error waiting for lock release, reason: ~w", [Reason]))}
+                            {error, lists:flatten(io_lib:format("Error waiting for lock release, reason: ~s",[Reason]))}
                     end;
                 {error, Reason} ->
-                    {error, lists:flatten(io_lib:format("Error obtaining lock status, reason: ~w", [Reason]))}
+                    {error, lists:flatten(io_lib:format("Error obtaining lock status, reason: ~s", [Reason]))}
             end;
         {error, Reason} ->
-            {error, lists:flatten(io_lib:format("Error while acquiring lock, reason: ~w", [Reason]))}
+            {error, lists:flatten(io_lib:format("Error while acquiring lock, reason: ~s", [Reason]))}
     end.
 
 

--- a/src/autocluster_consul.erl
+++ b/src/autocluster_consul.erl
@@ -684,7 +684,7 @@ create_session(Name, TTL) ->
                                 {'TTL', list_to_atom(service_ttl(TTL))}]) of
         {ok, Response} ->
             {ok, get_session_id(Response)};
-        {error, Err} ->
+        {error, _} = Err ->
             Err
     end.
 
@@ -820,7 +820,7 @@ wait_for_lock_release(false, _, _) -> ok;
 wait_for_lock_release(_, Index, Wait) ->
     case consul_kv_read(startup_lock_path(),
                         maybe_add_acl([{index, Index},
-                                       {wait, service_ttl(integer_to_list(Wait))}])) of
+                                       {wait, service_ttl(Wait)}])) of
         {ok, _}          -> ok;
         {error, _} = Err -> Err
     end.

--- a/test/src/autocluster_consul_tests.erl
+++ b/test/src/autocluster_consul_tests.erl
@@ -16,7 +16,8 @@ build_registration_body_test_() ->
                        {'Port',5672},
                        {'Check',
                          [{'Notes','RabbitMQ Auto-Cluster Plugin TTL Check'},
-                          {'TTL','30s'}]}],
+                          {'TTL','30s'},
+                          {'Status', 'passing'}]}],
         ?assertEqual(Expectation, autocluster_consul:build_registration_body())
        end},
       {"with addr set", fun() ->
@@ -27,7 +28,8 @@ build_registration_body_test_() ->
                        {'Port',5672},
                        {'Check',
                         [{'Notes','RabbitMQ Auto-Cluster Plugin TTL Check'},
-                         {'TTL','30s'}]}],
+                         {'TTL','30s'},
+                         {'Status', 'passing'}]}],
         ?assertEqual(Expectation, autocluster_consul:build_registration_body())
        end},
       {"with ttl set", fun() ->
@@ -45,6 +47,7 @@ build_registration_body_test_() ->
           {'Check',
             [{'Notes','RabbitMQ Auto-Cluster Plugin TTL Check'},
               {'TTL','30s'},
+              {'Status', 'passing'},
               {'Deregister_critical_service_after','257s'}]}],
         ?assertEqual(Expectation, autocluster_consul:build_registration_body())
       end},
@@ -83,7 +86,6 @@ service_id_test_() ->
 
 service_ttl_test() ->
   ?assertEqual("30s", autocluster_consul:service_ttl(30)).
-
 
 nodelist_test_() ->
   {
@@ -274,7 +276,7 @@ register_test_() ->
               ?assertEqual(8500, Port),
               ?assertEqual([v1, agent, service, register], Path),
               ?assertEqual([], Args),
-              Expect = <<"{\"ID\":\"rabbitmq\",\"Name\":\"rabbitmq\",\"Port\":5672,\"Check\":{\"Notes\":\"RabbitMQ Auto-Cluster Plugin TTL Check\",\"TTL\":\"30s\"}}">>,
+              Expect = <<"{\"ID\":\"rabbitmq\",\"Name\":\"rabbitmq\",\"Port\":5672,\"Check\":{\"Notes\":\"RabbitMQ Auto-Cluster Plugin TTL Check\",\"TTL\":\"30s\",\"Status\":\"passing\"}}">>,
               ?assertEqual(Expect, Body),
               {ok, []}
             end),
@@ -299,7 +301,7 @@ register_test_() ->
               ?assertEqual(8500, Port),
               ?assertEqual([v1, agent, service, register], Path),
               ?assertEqual([], Args),
-              Expect = <<"{\"ID\":\"rabbitmq\",\"Name\":\"rabbitmq\",\"Port\":5672,\"Check\":{\"Notes\":\"RabbitMQ Auto-Cluster Plugin TTL Check\",\"TTL\":\"30s\"},\"Tags\":[\"test-rabbit\"]}">>,
+              Expect = <<"{\"ID\":\"rabbitmq\",\"Name\":\"rabbitmq\",\"Port\":5672,\"Check\":{\"Notes\":\"RabbitMQ Auto-Cluster Plugin TTL Check\",\"TTL\":\"30s\",\"Status\":\"passing\"},\"Tags\":[\"test-rabbit\"]}">>,
               ?assertEqual(Expect, Body),
               {ok, []}
             end),
@@ -315,7 +317,7 @@ register_test_() ->
               ?assertEqual(8501, Port),
               ?assertEqual([v1, agent, service, register], Path),
               ?assertEqual([], Args),
-              Expect = <<"{\"ID\":\"rabbit:10.0.0.1\",\"Name\":\"rabbit\",\"Address\":\"10.0.0.1\",\"Port\":5671,\"Check\":{\"Notes\":\"RabbitMQ Auto-Cluster Plugin TTL Check\",\"TTL\":\"30s\"}}">>,
+              Expect = <<"{\"ID\":\"rabbit:10.0.0.1\",\"Name\":\"rabbit\",\"Address\":\"10.0.0.1\",\"Port\":5671,\"Check\":{\"Notes\":\"RabbitMQ Auto-Cluster Plugin TTL Check\",\"TTL\":\"30s\",\"Status\":\"passing\"}}">>,
               ?assertEqual(Expect, Body),
               {ok, []}
             end),
@@ -337,7 +339,7 @@ register_test_() ->
               ?assertEqual(8500, Port),
               ?assertEqual([v1, agent, service, register], Path),
               ?assertEqual([{token, "token-value"}], Args),
-              Expect = <<"{\"ID\":\"rabbitmq\",\"Name\":\"rabbitmq\",\"Port\":5672,\"Check\":{\"Notes\":\"RabbitMQ Auto-Cluster Plugin TTL Check\",\"TTL\":\"30s\"}}">>,
+              Expect = <<"{\"ID\":\"rabbitmq\",\"Name\":\"rabbitmq\",\"Port\":5672,\"Check\":{\"Notes\":\"RabbitMQ Auto-Cluster Plugin TTL Check\",\"TTL\":\"30s\",\"Status\":\"passing\"}}">>,
               ?assertEqual(Expect, Body),
               {ok, []}
             end),
@@ -358,7 +360,7 @@ register_test_() ->
               ?assertEqual(8500, Port),
               ?assertEqual([v1, agent, service, register], Path),
               ?assertEqual([{token, "token-value"}], Args),
-              Expect = <<"{\"ID\":\"rabbitmq:bob\",\"Name\":\"rabbitmq\",\"Address\":\"bob\",\"Port\":5672,\"Check\":{\"Notes\":\"RabbitMQ Auto-Cluster Plugin TTL Check\",\"TTL\":\"30s\"}}">>,
+              Expect = <<"{\"ID\":\"rabbitmq:bob\",\"Name\":\"rabbitmq\",\"Address\":\"bob\",\"Port\":5672,\"Check\":{\"Notes\":\"RabbitMQ Auto-Cluster Plugin TTL Check\",\"TTL\":\"30s\",\"Status\":\"passing\"}}">>,
               ?assertEqual(Expect, Body),
               {ok, []}
             end),
@@ -381,7 +383,7 @@ register_test_() ->
               ?assertEqual(8500, Port),
               ?assertEqual([v1, agent, service, register], Path),
               ?assertEqual([{token, "token-value"}], Args),
-              Expect = <<"{\"ID\":\"rabbitmq:bob.consul.node\",\"Name\":\"rabbitmq\",\"Address\":\"bob.consul.node\",\"Port\":5672,\"Check\":{\"Notes\":\"RabbitMQ Auto-Cluster Plugin TTL Check\",\"TTL\":\"30s\"}}">>,
+              Expect = <<"{\"ID\":\"rabbitmq:bob.consul.node\",\"Name\":\"rabbitmq\",\"Address\":\"bob.consul.node\",\"Port\":5672,\"Check\":{\"Notes\":\"RabbitMQ Auto-Cluster Plugin TTL Check\",\"TTL\":\"30s\",\"Status\":\"passing\"}}">>,
               ?assertEqual(Expect, Body),
               {ok, []}
             end),
@@ -408,7 +410,7 @@ register_test_() ->
               ?assertEqual(8500, Port),
               ?assertEqual([v1, agent, service, register], Path),
               ?assertEqual([{token, "token-value"}], Args),
-              Expect = <<"{\"ID\":\"rabbitmq:172.16.4.50\",\"Name\":\"rabbitmq\",\"Address\":\"172.16.4.50\",\"Port\":5672,\"Check\":{\"Notes\":\"RabbitMQ Auto-Cluster Plugin TTL Check\",\"TTL\":\"30s\"}}">>,
+              Expect = <<"{\"ID\":\"rabbitmq:172.16.4.50\",\"Name\":\"rabbitmq\",\"Address\":\"172.16.4.50\",\"Port\":5672,\"Check\":{\"Notes\":\"RabbitMQ Auto-Cluster Plugin TTL Check\",\"TTL\":\"30s\",\"Status\":\"passing\"}}">>,
               ?assertEqual(Expect, Body),
               {ok, []}
             end),
@@ -465,7 +467,6 @@ register_failure_test_() ->
       }
     ]
   }.
-
 
 send_health_check_pass_test_() ->
   {
@@ -616,3 +617,490 @@ with_warnings() ->
 
 without_warnings() ->
     "[{\"Node\": {\"Node\": \"rabbit2.internal.domain\", \"Address\": \"10.20.16.160\"}, \"Checks\": [{\"Node\": \"rabbit2.internal.domain\", \"CheckID\": \"service:rabbitmq\", \"Name\": \"Service \'rabbitmq\' check\", \"ServiceName\": \"rabbitmq\", \"Notes\": \"Connect to the port internally every 30 seconds\", \"Status\": \"passing\", \"ServiceID\": \"rabbitmq:172.172.16.4.50\", \"Output\": \"\"}, {\"Node\": \"rabbit2.internal.domain\", \"CheckID\": \"serfHealth\", \"Name\": \"Serf Health Status\", \"ServiceName\": \"\", \"Notes\": \"\", \"Status\": \"passing\", \"ServiceID\": \"\", \"Output\": \"Agent alive and reachable\"}], \"Service\": {\"Address\": \"172.16.4.51\", \"Port\": 5672, \"ID\": \"rabbitmq:172.16.4.51\", \"Service\": \"rabbitmq\", \"Tags\": [\"amqp\"]}}, {\"Node\": {\"Node\": \"rabbit1.internal.domain\", \"Address\": \"10.20.16.159\"}, \"Checks\": [{\"Node\": \"rabbit1.internal.domain\", \"CheckID\": \"service:rabbitmq\", \"Name\": \"Service \'rabbitmq\' check\", \"ServiceName\": \"rabbitmq\", \"Notes\": \"Connect to the port internally every 30 seconds\", \"Status\": \"passing\", \"ServiceID\": \"rabbitmq\", \"Output\": \"\"}, {\"Node\": \"rabbit1.internal.domain\", \"CheckID\": \"serfHealth\", \"Name\": \"Serf Health Status\", \"ServiceName\": \"\", \"Notes\": \"\", \"Status\": \"passing\", \"ServiceID\": \"\", \"Output\": \"Agent alive and reachable\"}], \"Service\": {\"Address\": \"172.172.16.51\", \"Port\": 5672, \"ID\": \"rabbitmq:172.172.16.51\", \"Service\": \"rabbitmq\", \"Tags\": [\"amqp\"]}}]".
+
+get_session_id_test() ->
+  ?assertEqual("session-id",
+               autocluster_consul:get_session_id({struct,[{<<"ID">>,
+                                                           <<"session-id">>}]})).
+startup_lock_path_test_() ->
+  {
+    foreach,
+    fun autocluster_testing:on_start/0,
+    fun autocluster_testing:on_finish/1,
+    [
+      {"default values", fun() ->
+        Expectation = ["rabbitmq", "default", "startup_lock"],
+        ?assertEqual(Expectation, autocluster_consul:startup_lock_path())
+       end},
+      {"with prefix set", fun() ->
+        Expectation = ["myprefix", "default", "startup_lock"],
+        os:putenv("CONSUL_LOCK_PREFIX", "myprefix"),
+        ?assertEqual(Expectation, autocluster_consul:startup_lock_path())
+       end},
+      {"with cluster name set", fun() ->
+        os:putenv("CLUSTER_NAME", "mycluster"),
+        Expectation = ["rabbitmq", "mycluster", "startup_lock"],
+        ?assertEqual(Expectation, autocluster_consul:startup_lock_path())
+      end}
+    ]
+  }.
+
+create_session_test_() ->
+  {
+    foreach,
+    fun() ->
+      autocluster_testing:reset(),
+      meck:new(autocluster_httpc, []),
+      [autocluster_httpc]
+    end,
+    fun autocluster_testing:on_finish/1,
+    [
+      {"without token",
+        fun() ->
+          meck:expect(autocluster_httpc, put,
+            fun(Scheme, Host, Port, Path, Args, Body) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("localhost", Host),
+              ?assertEqual(8500, Port),
+              ?assertEqual([v1, session, create], Path),
+              ?assertEqual([], Args),
+              Expect = <<"{\"Name\":\"node-name\",\"TTL\":\"30s\"}">>,
+              ?assertEqual(Expect, Body),
+              {ok, {struct,[{<<"ID">>, <<"session-id">>}]}}
+            end),
+          ?assertEqual({ok, "session-id"}, autocluster_consul:create_session("node-name", 30)),
+          ?assert(meck:validate(autocluster_httpc))
+        end},
+    {"with token",
+      fun() ->
+        meck:expect(autocluster_httpc, put,
+          fun(Scheme, Host, Port, Path, Args, Body) ->
+            ?assertEqual("http", Scheme),
+            ?assertEqual("localhost", Host),
+            ?assertEqual(8500, Port),
+            ?assertEqual([v1, session, create], Path),
+            ?assertEqual([{token, "token-value"}], Args),
+            Expect = <<"{\"Name\":\"node-name\",\"TTL\":\"30s\"}">>,
+            ?assertEqual(Expect, Body),
+            {ok, {struct,[{<<"ID">>, <<"session-id">>}]}}
+          end),
+        os:putenv("CONSUL_ACL_TOKEN", "token-value"),
+        ?assertEqual({ok, "session-id"}, autocluster_consul:create_session("node-name", 30)),
+        ?assert(meck:validate(autocluster_httpc))
+      end}
+    ]
+  }.
+
+
+get_lock_status_test_() ->
+  {
+    foreach,
+    fun() ->
+      autocluster_testing:reset(),
+      meck:new(autocluster_httpc, []),
+      [autocluster_httpc]
+    end,
+    fun autocluster_testing:on_finish/1,
+    [
+      {"without session",
+        fun() ->
+          meck:expect(autocluster_httpc, get,
+            fun(Scheme, Host, Port, Path, Args) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("localhost", Host),
+              ?assertEqual(8500, Port),
+              ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
+              ?assertEqual([], Args),
+              {ok,[{struct,[{<<"LockIndex">>,3},
+                            {<<"Key">>,<<"rabbitmq/default/startup_lock">>},
+                            {<<"Flags">>,0},
+                            {<<"Value">>,<<"W3t9XQ==">>},
+                            {<<"Session">>,<<"session-id">>},
+                            {<<"CreateIndex">>,8},
+                            {<<"ModifyIndex">>,21}]}]}
+            end),
+          ?assertEqual({ok, {true, 21}}, autocluster_consul:get_lock_status()),
+          ?assert(meck:validate(autocluster_httpc))
+        end},
+      {"with session",
+        fun() ->
+          meck:expect(autocluster_httpc, get,
+            fun(Scheme, Host, Port, Path, Args) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("localhost", Host),
+              ?assertEqual(8500, Port),
+              ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
+              ?assertEqual([], Args),
+              {ok,[{struct,[{<<"LockIndex">>,3},
+                            {<<"Key">>,<<"rabbitmq/default/startup_lock">>},
+                            {<<"Flags">>,0},
+                            {<<"Value">>,<<"W3t9XQ==">>},
+                            {<<"CreateIndex">>,8},
+                            {<<"ModifyIndex">>,21}]}]}
+            end),
+          ?assertEqual({ok, {false, 21}}, autocluster_consul:get_lock_status()),
+          ?assert(meck:validate(autocluster_httpc))
+        end},
+        {"with token",
+          fun() ->
+            meck:expect(autocluster_httpc, get,
+              fun(Scheme, Host, Port, Path, Args) ->
+                ?assertEqual("http", Scheme),
+                ?assertEqual("localhost", Host),
+                ?assertEqual(8500, Port),
+                ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
+                ?assertEqual([{token, "token-value"}], Args),
+                {ok,[{struct,[{<<"LockIndex">>,3},
+                              {<<"Key">>,<<"rabbitmq/default/startup_lock">>},
+                              {<<"Flags">>,0},
+                              {<<"Value">>,<<"W3t9XQ==">>},
+                              {<<"CreateIndex">>,8},
+                              {<<"ModifyIndex">>,21}]}]}
+              end),
+            os:putenv("CONSUL_ACL_TOKEN", "token-value"),
+            ?assertEqual({ok, {false, 21}}, autocluster_consul:get_lock_status()),
+            ?assert(meck:validate(autocluster_httpc))
+          end}
+    ]
+  }.
+
+wait_for_lock_release_with_session_test_() ->
+  {
+    foreach,
+    fun() ->
+      autocluster_testing:reset(),
+      meck:new(autocluster_httpc, []),
+      [autocluster_httpc]
+    end,
+    fun autocluster_testing:on_finish/1,
+    [
+      {"without token",
+        fun() ->
+          meck:expect(autocluster_httpc, get,
+            fun(Scheme, Host, Port, Path, Args) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("localhost", Host),
+              ?assertEqual(8500, Port),
+              ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
+              ?assertEqual([{index, 42}, {wait, "300s"}], Args),
+              {ok, []}
+            end),
+          ?assertEqual(ok, autocluster_consul:wait_for_lock_release(true, 42, 300)),
+          ?assert(meck:validate(autocluster_httpc))
+        end},
+      {"with token",
+        fun() ->
+          meck:expect(autocluster_httpc, get,
+            fun(Scheme, Host, Port, Path, Args) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("localhost", Host),
+              ?assertEqual(8500, Port),
+              ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
+              ?assertEqual([{index, 42}, {wait, "300s"}, {token, "token-value"}], Args),
+              {ok, []}
+            end),
+          os:putenv("CONSUL_ACL_TOKEN", "token-value"),
+          ?assertEqual(ok, autocluster_consul:wait_for_lock_release(true, 42, 300)),
+          ?assert(meck:validate(autocluster_httpc))
+        end}
+    ]
+  }.
+
+wait_for_lock_release_without_session_test() ->
+    ?assertEqual(ok, autocluster_consul:wait_for_lock_release(false, 0, 0)).
+
+acquire_lock_test_() ->
+  {
+    foreach,
+    fun() ->
+      autocluster_testing:reset(),
+      meck:new(autocluster_httpc, []),
+      [autocluster_httpc]
+    end,
+    fun autocluster_testing:on_finish/1,
+    [
+      {"successfully acquired",
+        fun() ->
+          meck:expect(autocluster_httpc, put,
+            fun(Scheme, Host, Port, Path, Args, Body) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("localhost", Host),
+              ?assertEqual(8500, Port),
+              ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
+              ?assertEqual([{acquire, session_id}], Args),
+              ?assertEqual([], Body),
+              {ok, true}
+            end),
+          ?assertEqual({ok, true}, autocluster_consul:acquire_lock(session_id)),
+          ?assert(meck:validate(autocluster_httpc))
+        end},
+        {"not acquired",
+          fun() ->
+            meck:expect(autocluster_httpc, put,
+              fun(Scheme, Host, Port, Path, Args, Body) ->
+                ?assertEqual("http", Scheme),
+                ?assertEqual("localhost", Host),
+                ?assertEqual(8500, Port),
+                ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
+                ?assertEqual([{acquire, session_id}], Args),
+                ?assertEqual([], Body),
+                {ok, false}
+              end),
+            ?assertEqual({ok, false}, autocluster_consul:acquire_lock(session_id)),
+            ?assert(meck:validate(autocluster_httpc))
+          end},
+      {"with token",
+        fun() ->
+          meck:expect(autocluster_httpc, put,
+            fun(Scheme, Host, Port, Path, Args, Body) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("localhost", Host),
+              ?assertEqual(8500, Port),
+              ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
+              ?assertEqual([{acquire, session_id}, {token, "token-value"}], Args),
+              ?assertEqual([], Body),
+              {ok, true}
+            end),
+          os:putenv("CONSUL_ACL_TOKEN", "token-value"),
+          ?assertEqual({ok, true}, autocluster_consul:acquire_lock(session_id)),
+          ?assert(meck:validate(autocluster_httpc))
+        end}
+    ]
+  }.
+
+release_lock_test_() ->
+  {
+    foreach,
+    fun() ->
+      autocluster_testing:reset(),
+      meck:new(autocluster_httpc, []),
+      [autocluster_httpc]
+    end,
+    fun autocluster_testing:on_finish/1,
+    [
+      {"successfully released",
+        fun() ->
+          meck:expect(autocluster_httpc, put,
+            fun(Scheme, Host, Port, Path, Args, Body) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("localhost", Host),
+              ?assertEqual(8500, Port),
+              ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
+              ?assertEqual([{release, session_id}], Args),
+              ?assertEqual([], Body),
+              {ok, true}
+            end),
+          ?assertEqual({ok, true}, autocluster_consul:release_lock(session_id)),
+          ?assert(meck:validate(autocluster_httpc))
+        end},
+        {"not released",
+          fun() ->
+            meck:expect(autocluster_httpc, put,
+              fun(Scheme, Host, Port, Path, Args, Body) ->
+                ?assertEqual("http", Scheme),
+                ?assertEqual("localhost", Host),
+                ?assertEqual(8500, Port),
+                ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
+                ?assertEqual([{release, session_id}], Args),
+                ?assertEqual([], Body),
+                {ok, false}
+              end),
+            ?assertEqual({ok, false}, autocluster_consul:release_lock(session_id)),
+            ?assert(meck:validate(autocluster_httpc))
+          end},
+      {"with token",
+        fun() ->
+          meck:expect(autocluster_httpc, put,
+            fun(Scheme, Host, Port, Path, Args, Body) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("localhost", Host),
+              ?assertEqual(8500, Port),
+              ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
+              ?assertEqual([{release, session_id}, {token, "token-value"}], Args),
+              ?assertEqual([], Body),
+              {ok, true}
+            end),
+          os:putenv("CONSUL_ACL_TOKEN", "token-value"),
+          ?assertEqual({ok, true}, autocluster_consul:release_lock(session_id)),
+          ?assert(meck:validate(autocluster_httpc))
+        end}
+    ]
+  }.
+
+consul_kv_read_test_() ->
+  {
+    foreach,
+    fun() ->
+      autocluster_testing:reset(),
+      meck:new(autocluster_httpc, []),
+      [autocluster_httpc]
+    end,
+    fun autocluster_testing:on_finish/1,
+    [
+      {"default values",
+        fun() ->
+          meck:expect(autocluster_httpc, get,
+            fun(Scheme, Host, Port, Path, Args) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("localhost", Host),
+              ?assertEqual(8500, Port),
+              ?assertEqual([v1, kv, "path", "to", "key"], Path),
+              ?assertEqual([{acquire, session_id}], Args),
+              {ok, []}
+            end),
+          ?assertEqual({ok, []}, autocluster_consul:consul_kv_read(["path", "to", "key"], [{acquire, session_id}])),
+          ?assert(meck:validate(autocluster_httpc))
+        end},
+      {"custom values",
+        fun() ->
+          meck:expect(autocluster_httpc, get,
+            fun(Scheme, Host, Port, Path, Args) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("consul.node.consul", Host),
+              ?assertEqual(8501, Port),
+              ?assertEqual([v1, kv, "path", "to", "key"], Path),
+              ?assertEqual([{acquire, session_id}], Args),
+              {ok, []}
+            end),
+          os:putenv("CONSUL_HOST", "consul.node.consul"),
+          os:putenv("CONSUL_PORT", "8501"),
+          ?assertEqual({ok, []}, autocluster_consul:consul_kv_read(["path", "to", "key"], [{acquire, session_id}])),
+          ?assert(meck:validate(autocluster_httpc))
+        end}
+    ]
+  }.
+
+consul_kv_write_test_() ->
+  {
+    foreach,
+    fun() ->
+      autocluster_testing:reset(),
+      meck:new(autocluster_httpc, []),
+      [autocluster_httpc]
+    end,
+    fun autocluster_testing:on_finish/1,
+    [
+      {"default values",
+        fun() ->
+          meck:expect(autocluster_httpc, put,
+            fun(Scheme, Host, Port, Path, Args, Body) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("localhost", Host),
+              ?assertEqual(8500, Port),
+              ?assertEqual([v1, kv, "path", "to", "key"], Path),
+              ?assertEqual([{acquire, session_id}], Args),
+              ?assertEqual([], Body),
+              {ok, []}
+            end),
+          ?assertEqual({ok, []}, autocluster_consul:consul_kv_write(["path", "to", "key"], [{acquire, session_id}], [])),
+          ?assert(meck:validate(autocluster_httpc))
+        end},
+      {"custom values",
+        fun() ->
+          meck:expect(autocluster_httpc, put,
+            fun(Scheme, Host, Port, Path, Args, Body) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("consul.node.consul", Host),
+              ?assertEqual(8501, Port),
+              ?assertEqual([v1, kv, "path", "to", "key"], Path),
+              ?assertEqual([{acquire, session_id}], Args),
+              ?assertEqual([], Body),
+              {ok, []}
+            end),
+          os:putenv("CONSUL_HOST", "consul.node.consul"),
+          os:putenv("CONSUL_PORT", "8501"),
+          ?assertEqual({ok, []}, autocluster_consul:consul_kv_write(["path", "to", "key"], [{acquire, session_id}], [])),
+          ?assert(meck:validate(autocluster_httpc))
+        end}
+    ]
+  }.
+
+consul_session_create_test_() ->
+  {
+    foreach,
+    fun() ->
+      autocluster_testing:reset(),
+      meck:new(autocluster_httpc, []),
+      [autocluster_httpc]
+    end,
+    fun autocluster_testing:on_finish/1,
+    [
+      {"default values",
+        fun() ->
+          meck:expect(autocluster_httpc, put,
+            fun(Scheme, Host, Port, Path, Args, Body) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("localhost", Host),
+              ?assertEqual(8500, Port),
+              ?assertEqual([v1, session, create], Path),
+              ?assertEqual([], Args),
+              ?assertEqual([], Body),
+              {ok, []}
+            end),
+          ?assertEqual({ok, []}, autocluster_consul:consul_session_create([], [])),
+          ?assert(meck:validate(autocluster_httpc))
+        end},
+      {"custom values",
+        fun() ->
+          meck:expect(autocluster_httpc, put,
+            fun(Scheme, Host, Port, Path, Args, Body) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("consul.node.consul", Host),
+              ?assertEqual(8501, Port),
+              ?assertEqual([v1, session, create], Path),
+              ?assertEqual([], Args),
+              ?assertEqual([], Body),
+              {ok, []}
+            end),
+          os:putenv("CONSUL_HOST", "consul.node.consul"),
+          os:putenv("CONSUL_PORT", "8501"),
+          ?assertEqual({ok, []}, autocluster_consul:consul_session_create([], [])),
+          ?assert(meck:validate(autocluster_httpc))
+        end}
+    ]
+  }.
+
+consul_session_renew_test_() ->
+  {
+    foreach,
+    fun() ->
+      autocluster_testing:reset(),
+      meck:new(autocluster_httpc, []),
+      [autocluster_httpc]
+    end,
+    fun autocluster_testing:on_finish/1,
+    [
+      {"default values",
+        fun() ->
+          meck:expect(autocluster_httpc, put,
+            fun(Scheme, Host, Port, Path, Args, Body) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("localhost", Host),
+              ?assertEqual(8500, Port),
+              ?assertEqual([v1, session, renew, session_id], Path),
+              ?assertEqual([], Args),
+              ?assertEqual([], Body),
+              {ok, []}
+            end),
+          ?assertEqual({ok, []}, autocluster_consul:consul_session_renew("session_id", [])),
+          ?assert(meck:validate(autocluster_httpc))
+        end},
+      {"custom values",
+        fun() ->
+          meck:expect(autocluster_httpc, put,
+            fun(Scheme, Host, Port, Path, Args, Body) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("consul.node.consul", Host),
+              ?assertEqual(8501, Port),
+              ?assertEqual([v1, session, renew, session_id], Path),
+              ?assertEqual([], Args),
+              ?assertEqual([], Body),
+              {ok, []}
+            end),
+          os:putenv("CONSUL_HOST", "consul.node.consul"),
+          os:putenv("CONSUL_PORT", "8501"),
+          ?assertEqual({ok, []}, autocluster_consul:consul_session_renew("session_id", [])),
+          ?assert(meck:validate(autocluster_httpc))
+        end}
+    ]
+  }.


### PR DESCRIPTION
Further to https://github.com/rabbitmq/rabbitmq-autocluster/issues/20 submitting a working implementation of startup locking for Consul backend.

 * The new property-based tests are missing. I had doubts on how to organise the code given that certain parts are somewhat biased towards etcd at the moment, hence looking for guidance here.
* The implementation closely follows the [Leader Election](https://www.consul.io/docs/guides/leader-election.html) guide from Consul docs.
* Added setting initial `passing` status for the service health check. Since updates begin right after registration, there is hardly a reason this would be harmful. It also helps with testing locally when all nodes run on the same host and would otherwise keep it `critical` throughout most of the startup process and thus fail to cluster.

The following compose file was used for verification:
```
version: '2'
services:
  consul:
    image: consul
    container_name: consul
    networks:
      - rabbitmq_network
    ports:
      - "8500:8500"

  rabbit-node0:
    depends_on:
      - consul
    image: rabbitmq-autocluster
    container_name: node0
    networks:
      - rabbitmq_network
    environment:
      AUTOCLUSTER_TYPE: consul
      CONSUL_HOST: consul
      CONSUL_PORT: 8500
      CONSUL_SERVICE_TTL: 60
      AUTOCLUSTER_CLEANUP: 'true'
      CLEANUP_WARN_ONLY: 'false'
      CONSUL_SVC_ADDR_AUTO: 'true'
    ports:
      - "15672:15672"

  rabbit-node1:
    depends_on:
      - consul
    image: rabbitmq-autocluster
    container_name: node1
    networks:
      - rabbitmq_network
    environment:
      AUTOCLUSTER_TYPE: consul
      CONSUL_HOST: consul
      CONSUL_PORT: 8500
      CONSUL_SERVICE_TTL: 60
      AUTOCLUSTER_CLEANUP: 'true'
      CLEANUP_WARN_ONLY: 'false'
      CONSUL_SVC_ADDR_AUTO: 'true'

  rabbit-node2:
    depends_on:
      - consul
    image: rabbitmq-autocluster
    container_name: node2
    networks:
      - rabbitmq_network
    environment:
      AUTOCLUSTER_TYPE: consul
      CONSUL_HOST: consul
      CONSUL_PORT: 8500
      CONSUL_SERVICE_TTL: 60
      AUTOCLUSTER_CLEANUP: 'true'
      CLEANUP_WARN_ONLY: 'false'
      CONSUL_SVC_ADDR_AUTO: 'true'

networks:
  rabbitmq_network:
    driver: bridge
```
