### PR TITLE
Change message format

### DIFF
--- a/src/autocluster_etcd.erl
+++ b/src/autocluster_etcd.erl
@@ -104,7 +104,7 @@ lock(UniqueId, _, EndTime) ->
             wait_for_lock_release(),
             lock(UniqueId, time_compat:erlang_system_time(seconds), EndTime);
         {error, Reason} ->
-            {error, lists:flatten(io_lib:format("Error while acquiring the lock, reason: ~w", [Reason]))}
+            {error, lists:flatten(io_lib:format("Error while acquiring the lock, reason: ~p", [Reason]))}
     end.
 
 

--- a/src/autocluster_util.erl
+++ b/src/autocluster_util.erl
@@ -308,7 +308,7 @@ stringify_error({ok, _} = Res) ->
 stringify_error({error, Str}) when is_list(Str) ->
     {error, Str};
 stringify_error({error, Term}) ->
-    {error, lists:flatten(io_lib:format("~w", [Term]))}.
+    {error, lists:flatten(io_lib:format("~p", [Term]))}.
 
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
```
AUTOCLUSTER_TYPE=etcd ETCD_HOST=ip_does_not_exist gmake run-broker 
```

The error message is:
```
=ERROR REPORT==== 22-May-2017::11:53:28 ===
autocluster: Step acquire_startup_lock failed, will conitnue nevertheless. Failure reason: Failed to acquire startup lock: Error while acquiring the lock, reason: [123,102,97,105,108,101,100,95,99,111,110,110,101,99,116,44,91,123,116,111,95,97,100,100,114,101,115,115,44,123,91,49,48,53,44,49,49,50,44,57,53,44,49,48,48,44,49,49,49,44,49,48,49,44,49,49,53,44,57,53,44,49,49,48,44,49,49,49,44,49,49,54,44,57,53,44,49,48,49,44,49,50,48,44,49,48,53,44,49,49,53,44,49,49,54,93,44,50,51,55,57,125,125,44,123,105,110,101,116,44,91,105,110,101,116,93,44,110,120,100,111,109,97,105,110,125,93,125].
```

Should we change `~w` with `~p` ?

```
=ERROR REPORT==== 22-May-2017::11:54:50 ===
autocluster: Step acquire_startup_lock failed, will conitnue nevertheless. Failure reason: Failed to acquire startup lock: Error while acquiring the lock, reason: "{failed_connect,[{to_address,{\"ip_does_not_exist\",2379}},\n {inet,[inet],nxdomain}]}".
```