### PR TITLE
Add HTTP proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ The following settings are available for all service discovery backends:
   <dd>If cluster cleanup is enabled, this is the interval that specifies how often to look for dead nodes to remove (in seconds). <em>Added in v0.5</em></dd>
   <dt>Cleanup Warn Only</dt>
   <dd>If set, the plugin will only warn about nodes that it would cleanup and will not perform any destructive actions on the cluster. <em>Added in v0.5</em></dd>
+  <dt>HTTP Proxy</dt>
+  <dd>If set, the given HTTP URL will be used as a proxy to connect to the service discovery backend.</dd>
+  <dt>HTTPS Proxy</dt>
+  <dd>If set, the given HTTPS URL will be used as a proxy to connect to the service discovery backend.</dd>
+  <dt>No Proxy</dt>
+  <dd>List of host names which shouldn't use any proxy.</dd>
   <dl/>
 
 #### Settings Details
@@ -336,7 +342,7 @@ packages:
 - docker-engine
 runcmd:
 - docker run -d --name rabbitmq --net=host -p 4369:4369 -p 5672:5672 -p 15672:15672 -p 25672:25672 gavinmroy/rabbitmq-autocluster
-```                                    
+```
 ### Consul configuration
 
 The following settings impact the configuration of the [Consul](http://consul.io) backend for the autocluster plugin:
@@ -452,7 +458,7 @@ The [example](https://github.com/rabbitmq/rabbitmq-autocluster/tree/stable/examp
 how to create a dynamic RabbitMQ cluster using:
 
  * [Docker compose](https://docs.docker.com/compose/)
- * [Consul](https://www.consul.io) 
+ * [Consul](https://www.consul.io)
  * [HA proxy](https://github.com/docker/dockercloud-haproxy)
 
 ### DNS configuration

--- a/include/autocluster.hrl
+++ b/include/autocluster.hrl
@@ -20,6 +20,9 @@
          {config, longname,              "RABBITMQ_USE_LONGNAME",  false,        atom,    false},
          {config, node_name,             "RABBITMQ_NODENAME",      "rabbit",     string,  false},
          {config, node_type,             "RABBITMQ_NODE_TYPE",     disc,         atom,    false},
+         {config, http_proxy,            "HTTP_PROXY",            "undefined",   string,  false},
+         {config, https_proxy,           "HTTPS_PROXY",           "undefined",   string,  false},
+         {config, no_proxy,              "NO_PROXY",              "undefined",   string,  false},
 
          {config, aws_autoscaling,       "AWS_AUTOSCALING",        false,        atom,    false}, %% AWS
          {config, aws_ec2_tags,          "AWS_EC2_TAGS",           [],           proplist,  false},


### PR DESCRIPTION
In case of limited connectivity, this change allows to set HTTP(S) proxy to connect to the service discovery backend.

Credits to @jjonek.