### PR TITLE
Retry in case create_session gets error 500

### DIFF
--- a/src/autocluster_consul.erl
+++ b/src/autocluster_consul.erl
@@ -61,14 +61,14 @@ nodelist() ->
 maybe_create_session(Who, N) when N > 0 ->
     case create_session(Who, autocluster_config:get(consul_svc_ttl)) of
         {error, "500"} -> 
-	    autocluster_log:warning("Error 500 while creating a session, " ++
+	    autocluster_log:warning("Error 500 while creating a Consul session, " ++
 					" ~p retries left", [N]),
 	    timer:sleep(2000),
 	    maybe_create_session(Who, N -1);
         Value -> Value
     end;
 maybe_create_session(_Who, _N) ->
-    lists:flatten(io_lib:format("Error while creating a session,"++ 
+    lists:flatten(io_lib:format("Error while creating a Consul session,"++
 				    "reason: too many 'Error 500' ", [])).
 
 
@@ -88,7 +88,7 @@ lock(Who) ->
             lock(SessionId, Now, EndTime);
 
         {error, Reason} ->
-           lists:flatten(io_lib:format("Error while creating a session, reason: ~p", [Reason]))
+           lists:flatten(io_lib:format("Error while creating a Consul session, reason: ~p", [Reason]))
     end.
 
 

--- a/src/autocluster_consul.erl
+++ b/src/autocluster_consul.erl
@@ -30,7 +30,7 @@
 
 -include("autocluster.hrl").
 
--define(CREATE_SESSION_RETRY, 10).
+-define(CREATE_SESSION_RETRIES, 10).
 
 
 %%--------------------------------------------------------------------
@@ -55,7 +55,7 @@ nodelist() ->
 
 
 %% @doc Tries to create a session.
-%% if there is an Error 500 retries until ?CREATE_SESSION_RETRY
+%% if there is an Error 500 retries until ?CREATE_SESSION_RETRIES
 
 -spec maybe_create_session(string(), pos_integer()) -> {ok,string()} | {error, string()}.
 maybe_create_session(Who, N) when N > 0 ->
@@ -80,7 +80,7 @@ maybe_create_session(_Who, _N) ->
 %% @end.
 -spec lock(string()) -> ok | {error, string()}.
 lock(Who) ->
-    case maybe_create_session(Who, ?CREATE_SESSION_RETRY) of
+    case maybe_create_session(Who, ?CREATE_SESSION_RETRIES) of
         {ok, SessionId} ->
             start_session_ttl_updater(SessionId),
             Now = time_compat:erlang_system_time(seconds),


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-autocluster/issues/42

When Consul is starting, the sockets are up, but the end points are not ready yet

Consul raises the following error when the plugin tries to create a session:
```
2017/08/22 08:55:02 [ERR] http: Request PUT /v1/session/create, error: No cluster leader from=127.0.0.1:58446
```

And the broker gets down:

```
=INFO REPORT==== 22-Aug-2017::08:47:36 ===
Error description:
   {could_not_start,rabbit,
       {{case_clause,"Error while creating a session, reason: \"500\""},
        [{autocluster,acquire_startup_lock,1,
             [{file,"src/autocluster.erl"},{line,212}]},
         {autocluster,run_steps,1,[{file,"src/autocluster.erl"},{line,131}]},
```

With this fix, in case the session creation raises `Error 500` [it retries to execute](https://github.com/rabbitmq/rabbitmq-autocluster/blob/rabbitmq-autocluster-42/src/autocluster_consul.erl#L67)  the create session.


To reproduce the issue:

1.  Run a clean RabbitMQ instance
2.  When is "Starting broker.." start a clean Consul instance 