### PR TITLE
Add HTTP(S) Proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ The following settings are available for all service discovery backends:
   <dd>If cluster cleanup is enabled, this is the interval that specifies how often to look for dead nodes to remove (in seconds). <em>Added in v0.5</em></dd>
   <dt>Cleanup Warn Only</dt>
   <dd>If set, the plugin will only warn about nodes that it would cleanup and will not perform any destructive actions on the cluster. <em>Added in v0.5</em></dd>
+  <dt>HTTP Proxy</dt>
+  <dd>If set, the given HTTP URL will be used as a proxy to connect to the service discovery backend.</dd>
+  <dt>HTTPS Proxy</dt>
+  <dd>If set, the given HTTPS URL will be used as a proxy to connect to the service discovery backend.</dd>
+  <dt>Proxy Exclusions</dt>
+  <dd>List of host names which shouldn't use any proxy.</dd>
+  <dd>When using environment variables, the NoProxy list must be provided as a comma separated string: <code>PROXY_EXCLUSIONS="localhost, 127.0.0.1"</code></dd>
+
   <dl/>
 
 #### Settings Details
@@ -336,7 +344,7 @@ packages:
 - docker-engine
 runcmd:
 - docker run -d --name rabbitmq --net=host -p 4369:4369 -p 5672:5672 -p 15672:15672 -p 25672:25672 gavinmroy/rabbitmq-autocluster
-```                                    
+```
 ### Consul configuration
 
 The following settings impact the configuration of the [Consul](http://consul.io) backend for the autocluster plugin:
@@ -452,7 +460,7 @@ The [example](https://github.com/rabbitmq/rabbitmq-autocluster/tree/stable/examp
 how to create a dynamic RabbitMQ cluster using:
 
  * [Docker compose](https://docs.docker.com/compose/)
- * [Consul](https://www.consul.io) 
+ * [Consul](https://www.consul.io)
  * [HA proxy](https://github.com/docker/dockercloud-haproxy)
 
 ### DNS configuration

--- a/include/autocluster.hrl
+++ b/include/autocluster.hrl
@@ -19,6 +19,9 @@
          {config, longname,              "RABBITMQ_USE_LONGNAME",  false,        atom,    false},
          {config, node_name,             "RABBITMQ_NODENAME",      "rabbit",     string,  false},
          {config, node_type,             "RABBITMQ_NODE_TYPE",     disc,         atom,    false},
+         {config, http_proxy,            "HTTP_PROXY",             "undefined",  string,  false},
+         {config, https_proxy,           "HTTPS_PROXY",            "undefined",  string,  false},
+         {config, proxy_exclusions,      "PROXY_EXCLUSIONS",       [],           list,  false},
 
          {config, aws_autoscaling,       "AWS_AUTOSCALING",        false,        atom,    false}, %% AWS
          {config, aws_ec2_tags,          "AWS_EC2_TAGS",           [],           proplist,  false},

--- a/src/autocluster.erl
+++ b/src/autocluster.erl
@@ -188,6 +188,7 @@ get_run_steps_state() ->
 %%--------------------------------------------------------------------
 -spec initialize_backend(#startup_state{}) -> {ok, #startup_state{}} | {error, iolist()}.
 initialize_backend(State) ->
+  ok = maybe_configure_proxy(),
   case detect_backend(autocluster_config:get(backend)) of
     {ok, Name, Mod} ->
       {ok, State#startup_state{backend_name = Name, backend_module = Mod}};
@@ -584,3 +585,49 @@ with_stopped_app(Fun) ->
     ensure_app_stopped(),
     Fun(),
     ensure_app_running().
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Configure http proxy options if specified in configuration.
+%% @end
+%%--------------------------------------------------------------------
+-spec maybe_configure_proxy() -> ok.
+maybe_configure_proxy() ->
+  NoProxy = autocluster_config:get(proxy_exclusions),
+  ok = maybe_set_proxy(proxy, autocluster_config:get(http_proxy), NoProxy),
+  ok = maybe_set_proxy(https_proxy, autocluster_config:get(https_proxy), NoProxy),
+  ok.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Set httpc proxy options.
+%% @end
+%%--------------------------------------------------------------------
+-spec maybe_set_proxy(Option :: atom(),
+                      ProxyUrl :: string(),
+                      NoProxy :: list()) -> ok | {error, Reason :: term()}.
+maybe_set_proxy(_Option, "undefined", _NoProxy) -> ok;
+maybe_set_proxy(Option, ProxyUrl, NoProxy) ->
+  case parse_proxy_uri(Option, ProxyUrl) of
+    {ok, {_Scheme, _UserInfo, Host, Port, _Path, _Query}} ->
+      autocluster_log:debug(
+        "Configuring ~s: ~p, exclusions: ~p", [Option, {Host, Port}, NoProxy]),
+      httpc:set_options([{Option, {{Host, Port}, NoProxy}}]);
+    {error, Reason} -> {error, Reason}
+  end.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc Support defining proxy address with or without uri scheme.
+%% @end
+%%--------------------------------------------------------------------
+-spec parse_proxy_uri(ProxyType :: atom(), ProxyUrl :: string()) -> tuple().
+parse_proxy_uri(ProxyType, ProxyUrl) ->
+  case http_uri:parse(ProxyUrl) of
+    {ok, Result} -> {ok, Result};
+    {error, _} ->
+      case ProxyType of
+        proxy -> http_uri:parse("http://" ++ ProxyUrl);
+        https_proxy -> http_uri:parse("https://" ++ ProxyUrl)
+      end
+  end.

--- a/src/autocluster_config.erl
+++ b/src/autocluster_config.erl
@@ -124,4 +124,6 @@ normalize(Config, Value) when Config#config.type =:= integer ->
 normalize(Config, Value) when Config#config.type =:= string ->
   autocluster_util:as_string(Value);
 normalize(Config, Value) when Config#config.type =:= proplist ->
-  autocluster_util:as_proplist(Value).
+  autocluster_util:as_proplist(Value);
+normalize(Config, Value) when Config#config.type =:= list ->
+  autocluster_util:as_list(Value).

--- a/src/autocluster_util.erl
+++ b/src/autocluster_util.erl
@@ -9,6 +9,7 @@
 -export([as_atom/1,
          as_integer/1,
          as_string/1,
+         as_list/1,
          backend_module/0,
          nic_ipv4/1,
          node_hostname/1,
@@ -90,6 +91,32 @@ as_string(Value) when is_integer(Value) ->
 as_string(Value) when is_list(Value) ->
   lists:flatten(Value);
 as_string(Value) ->
+  autocluster_log:error("Unexpected data type for list value: ~p~n",
+                        [Value]),
+  Value.
+
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Return the passed in value as a list of strings.
+%% @end
+%%--------------------------------------------------------------------
+-spec as_list(Value :: stringifyable() | list()) -> list().
+as_list([]) -> [];
+as_list(Value) when is_atom(Value) ; is_integer(Value) ; is_binary(Value) ->
+  [Value];
+as_list(Value) when is_list(Value) ->
+  case io_lib:printable_list(Value) or io_lib:printable_unicode_list(Value) of
+    true -> [case string:to_float(S) of
+               {Float, []} -> Float;
+               _ -> case string:to_integer(S) of
+                      {Integer, []} -> Integer;
+                      _ -> string:strip(S)
+                    end
+             end || S <- string:tokens(Value, ",")];
+    false -> Value
+  end;
+as_list(Value) ->
   autocluster_log:error("Unexpected data type for list value: ~p~n",
                         [Value]),
   Value.

--- a/test/src/autocluster_config_tests.erl
+++ b/test/src/autocluster_config_tests.erl
@@ -52,6 +52,13 @@ app_envvar_test_() ->
           application:set_env(autocluster, consul_svc, <<"rabbit">>),
           ?assertEqual("rabbit", autocluster_config:get(consul_svc))
         end
+      },
+      {
+        "app list value when string",
+        fun() ->
+          application:set_env(autocluster, proxy_exclusions, "foo,42,42.5"),
+          ?assertEqual(["foo", 42, 42.5], autocluster_config:get(proxy_exclusions))
+        end
       }
     ]
   }.
@@ -107,7 +114,13 @@ os_envvar_test_() ->
           ?assertEqual([{"region", "us-west-2"}, {"service", "rabbitmq"}],
                        autocluster_config:get(aws_ec2_tags))
         end
+      },
+      {
+        "proxy exclusions",
+        fun() ->
+          os:putenv("PROXY_EXCLUSIONS", "foo,42,42.5"),
+          ?assertEqual(["foo", 42, 42.5], autocluster_config:get(proxy_exclusions))
+        end
       }
     ]
   }.
-

--- a/test/src/autocluster_tests.erl
+++ b/test/src/autocluster_tests.erl
@@ -58,6 +58,24 @@ initialize_backend_starts_required_apps_test_() ->
         ?assert(meck:called(application, ensure_all_started, '_'))
     end).
 
+initialize_backend_with_proxy_test_() ->
+  autocluster_testing:with_mock(
+    [{application, [unstick, passthrough]}],
+    fun () ->
+        meck:expect(application, ensure_all_started, fun (rabbitmq_aws) -> ok end),
+        autocluster_testing:reset(),
+        os:putenv("AUTOCLUSTER_TYPE", "aws"),
+        os:putenv("HTTP_PROXY", "foobar.com"),
+        os:putenv("HTTPS_PROXY", "foobar.com"),
+        os:putenv("PROXY_EXCLUSIONS", "0.0.0.0, 1.1.1.1"),
+        inets:start(),
+        {ok, _} = autocluster:initialize_backend(#startup_state{}),
+        {ok, {{"foobar.com", 80}, ["0.0.0.0", "1.1.1.1"]}} = httpc:get_option(proxy),
+        {ok, {{"foobar.com", 443}, ["0.0.0.0", "1.1.1.1"]}} = httpc:get_option(https_proxy),
+        ?assert(meck:called(application, ensure_all_started, '_')),
+        inets:stop()
+    end).
+
 initialize_backend_update_required_fields_for_all_known_backends_test_() ->
   Cases = [{aws, autocluster_aws}
           ,{consul, autocluster_consul}

--- a/test/src/autocluster_util_tests.erl
+++ b/test/src/autocluster_util_tests.erl
@@ -102,6 +102,33 @@ as_string_test_() ->
   }.
 
 
+as_list_test_() ->
+  {
+    foreach,
+    fun() ->
+      autocluster_testing:reset(),
+      meck:new(autocluster_log, []),
+      [autocluster_log]
+    end,
+    fun autocluster_testing:on_finish/1,
+    [
+      {"integer", fun() -> ?assertEqual([42], autocluster_util:as_list(42)) end},
+      {"atom", fun() -> ?assertEqual(['42'], autocluster_util:as_list('42')) end},
+      {"binary", fun() -> ?assertEqual([<<"42">>], autocluster_util:as_list(<<"42">>)) end},
+      {"string", fun() -> ?assertEqual(["foo"], autocluster_util:as_list("foo")) end},
+      {"string-list", fun() -> ?assertEqual(["foo", 42, 42.5], autocluster_util:as_list("foo,42,42.5")) end},
+      {"other",
+        fun() ->
+          meck:expect(autocluster_log, error,
+            fun(_Message, Args) -> ?assertEqual([#config{}], Args) end),
+          ?assertEqual(#config{}, autocluster_util:as_list(#config{})),
+          ?assert(meck:validate(autocluster_log))
+        end
+      }
+    ]
+  }.
+
+
 backend_module_test_() ->
   {
     foreach,


### PR DESCRIPTION
In case of limited connectivity, this change allows to set HTTP(S) proxy to connect to the service discovery backend.

The following changes have been made since #43 :
1. Moved to `stable` branch as target.
2. Added support for list configuration arguments.
3. Added tests for `utils` and `config` modules.
4. Renamed config value `no_proxy` to `proxy_exclusions`.

Credits to @jjonek.