### PR TITLE
Add auto-cluster compose examples

### DIFF
--- a/examples/compose_consul_haproxy/README.md
+++ b/examples/compose_consul_haproxy/README.md
@@ -1,6 +1,4 @@
-RabbitMQ-Autoclsuter Consul example
---
-Dynamic RabbitMQ cluster using:
+This example shows how to create a dynamic RabbitMQ cluster using:
 
 1. [Docker compose](https://docs.docker.com/compose/)
 
@@ -8,17 +6,24 @@ Dynamic RabbitMQ cluster using:
 
 3. [HA proxy](https://github.com/docker/dockercloud-haproxy)
 
+---
 
-Execute
---
+How to run:
+
 ```
-cd  examples/compose_consul_haproxy 
 docker-compose up
+```
+
+How to scale:
+
+```
 docker-compose scale rabbit=3
 ```
 
-Check
---
+
+---
+
+Check running status:
 
 - Consul Management: http://localhost:8500/ui/ 
 - RabbitMQ Management: http://localhost:15672/#/

--- a/examples/compose_etcd2/README.md
+++ b/examples/compose_etcd2/README.md
@@ -1,0 +1,10 @@
+This example show how to create a static RabbitMQ cluster using [Docker compose](https://docs.docker.com/compose/) and [etcd2](https://github.com/coreos/etcd) as back-end
+==
+
+Run:
+```
+docker-compose up
+```
+
+It creates a cluster with 2 nodes and the UI enabled. 
+You can customize the `rabbitmq.config` inside `conf/rabbitmq.config`

--- a/examples/compose_etcd2/README.md
+++ b/examples/compose_etcd2/README.md
@@ -1,10 +1,16 @@
-This example show how to create a static RabbitMQ cluster using [Docker compose](https://docs.docker.com/compose/) and [etcd2](https://github.com/coreos/etcd) as back-end
-==
+This example shows how to create a static RabbitMQ cluster using:
+- [Docker compose](https://docs.docker.com/compose/) 
+- [etcd2](https://github.com/coreos/etcd) as back-end
 
-Run:
+---
+
+How to run:
 ```
 docker-compose up
 ```
 
 It creates a cluster with 2 nodes and the UI enabled. 
+
 You can customize the `rabbitmq.config` inside `conf/rabbitmq.config`
+
+ 

--- a/examples/compose_etcd2/README.md
+++ b/examples/compose_etcd2/README.md
@@ -1,16 +1,27 @@
 This example shows how to create a static RabbitMQ cluster using:
-- [Docker compose](https://docs.docker.com/compose/) 
-- [etcd2](https://github.com/coreos/etcd) as back-end
+
+1. [Docker compose](https://docs.docker.com/compose/) 
+
+2. [etcd2](https://github.com/coreos/etcd) as back-end
 
 ---
+
+It creates a cluster with 2 nodes and the UI enabled. 
+
+You can customize the `rabbitmq.config` inside `conf/rabbitmq.config`
+
 
 How to run:
 ```
 docker-compose up
 ```
 
-It creates a cluster with 2 nodes and the UI enabled. 
 
-You can customize the `rabbitmq.config` inside `conf/rabbitmq.config`
+---
+
+Check running status:
+
+- RabbitMQ Management: http://localhost:15672/#/
+
 
  

--- a/examples/compose_etcd2/conf/rabbitmq.config
+++ b/examples/compose_etcd2/conf/rabbitmq.config
@@ -1,0 +1,12 @@
+[ { rabbit, [
+  { loopback_users, [ ] } ] },
+
+{autocluster,
+  [
+    {startup_delay, 15},
+    {backend, etcd},
+    {etcd_host, "etcd0"},
+    {etcd_port, 2379}
+   ]}
+
+].

--- a/examples/compose_etcd2/docker-compose.yml
+++ b/examples/compose_etcd2/docker-compose.yml
@@ -1,0 +1,66 @@
+version: "2"
+services:
+  etcd0:
+    image: quay.io/coreos/etcd:v2.1.1
+    networks:
+      - back
+    ports:
+     - "4001:4001"
+     - 2380
+     - 2379
+    command:
+      - --name=etcd0
+      - --initial-cluster-token=etcd-cluster-1
+      - --initial-cluster=etcd0=http://etcd0:2380
+      - --initial-cluster-state=new
+      - --initial-advertise-peer-urls=http://etcd0:2380
+      - --listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001
+      - --listen-peer-urls=http://0.0.0.0:2380
+      - --advertise-client-urls=http://etcd0:2379  
+  rabbit_node_1:
+    environment:
+      - RABBITMQ_ERLANG_COOKIE='secret_cookie'
+      - AUTOCLUSTER_TYPE=etcd
+      - AUTOCLUSTER_DELAY=10
+      - ETCD_HOST=etcd0
+    networks:
+      - back
+    depends_on:
+      - etcd0
+    hostname: rabbit_node_1
+    image: pivotalrabbitmq/rabbitmq-autocluster
+    ports:
+      - "15672:15672"
+      - "5672:5672"
+    tty: true
+    volumes:
+      - rabbit1:/var/lib/rabbitmq
+      - ./conf/:/etc/rabbitmq/
+  rabbit_node_2:
+    environment:
+      - RABBITMQ_ERLANG_COOKIE='secret_cookie'
+      - AUTOCLUSTER_TYPE=etcd
+      - AUTOCLUSTER_DELAY=40
+      - ETCD_HOST=etcd0
+    networks:
+      - back
+    hostname: rabbit_node_2
+    image: pivotalrabbitmq/rabbitmq-autocluster
+    depends_on:
+      - rabbit_node_1
+      - etcd0
+    ports:
+      - "15673:15672"
+      - "5673:5672"
+    tty: true
+    volumes:
+      - rabbit2:/var/lib/rabbitmq
+      - ./conf/:/etc/rabbitmq/
+volumes:
+  rabbit1:
+    driver: local
+  rabbit2:
+    driver: local
+
+networks:
+  back:

--- a/examples/compose_etcd2_haproxy/README.md
+++ b/examples/compose_etcd2_haproxy/README.md
@@ -1,0 +1,17 @@
+This example shows how to create a static RabbitMQ cluster using:
+:
+
+1. [Docker compose](https://docs.docker.com/compose/) 
+
+2. [etcd2](https://github.com/coreos/etcd) as back-end  
+
+3. [HA proxy](https://github.com/docker/dockercloud-haproxy)
+
+```
+git clone https://github.com/Gsantomaggio/rabbitmqexample.git .
+cd cluster_docker_compose/etcd2_ha
+docker-compose up
+docker-compose scale rabbit=3
+```
+
+You can customize the `rabbitmq.config` inside `conf/rabbitmq.config`

--- a/examples/compose_etcd2_haproxy/README.md
+++ b/examples/compose_etcd2_haproxy/README.md
@@ -1,5 +1,5 @@
-This example shows how to create a static RabbitMQ cluster using:
-:
+This example shows how to create a dynamic RabbitMQ cluster using:
+
 
 1. [Docker compose](https://docs.docker.com/compose/) 
 
@@ -7,11 +7,25 @@ This example shows how to create a static RabbitMQ cluster using:
 
 3. [HA proxy](https://github.com/docker/dockercloud-haproxy)
 
+---
+
+You can customize the `rabbitmq.config` inside `conf/rabbitmq.config`
+
+
+How to run:
 ```
-git clone https://github.com/Gsantomaggio/rabbitmqexample.git .
-cd cluster_docker_compose/etcd2_ha
 docker-compose up
+```
+
+How to scale:
+
+```
 docker-compose scale rabbit=3
 ```
 
-You can customize the `rabbitmq.config` inside `conf/rabbitmq.config`
+---
+
+Check running status:
+
+- RabbitMQ Management: http://localhost:15672/#/
+

--- a/examples/compose_etcd2_haproxy/conf/rabbitmq.config
+++ b/examples/compose_etcd2_haproxy/conf/rabbitmq.config
@@ -1,0 +1,14 @@
+[ { rabbit, [
+  { loopback_users, [ ] } ] },
+
+{autocluster,
+  [
+    {cluster_cleanup, true},
+    {cleanup_warn_only, false},
+    {startup_delay, 15},
+    {backend, etcd},
+    {etcd_host, "etcd0"},
+    {etcd_port, 2379}
+   ]}
+
+].

--- a/examples/compose_etcd2_haproxy/docker-compose.yml
+++ b/examples/compose_etcd2_haproxy/docker-compose.yml
@@ -1,0 +1,59 @@
+version: "2"
+services:
+   rabbit:
+    environment:
+      - RABBITMQ_ERLANG_COOKIE='secret_cookie'
+      - TCP_PORTS=15672, 5672
+      - AUTOCLUSTER_TYPE=etcd
+      - AUTOCLUSTER_DELAY=20
+      - ETCD_HOST=etcd0
+      - AUTOCLUSTER_CLEANUP=true
+      - CLEANUP_WARN_ONLY=false
+    networks:
+      - back
+    image: pivotalrabbitmq/rabbitmq-autocluster
+    expose:
+      - 15672
+      - 5672
+      - 5671
+      - 15671
+    tty: true
+    volumes:
+      - ./conf/:/etc/rabbitmq/
+   lb:
+    image: dockercloud/haproxy
+    environment:
+      - MODE=tcp
+    links:
+      - rabbit
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - 15672:15672
+      - 5672:5672
+    networks:
+      - back
+   etcd0:
+    image: quay.io/coreos/etcd:v2.1.1
+    networks:
+      - back
+    ports:
+     - "4001:4001"
+     - 2380
+     - 2379
+    command:
+      - --name=etcd0
+      - --initial-cluster-token=etcd-cluster-1
+      - --initial-cluster=etcd0=http://etcd0:2380
+      - --initial-cluster-state=new
+      - --initial-advertise-peer-urls=http://etcd0:2380
+      - --listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001
+      - --listen-peer-urls=http://0.0.0.0:2380
+      - --advertise-client-urls=http://etcd0:2379
+      
+volumes:
+  rabbit1:
+    driver: local
+
+networks:
+  back:


### PR DESCRIPTION
Add auto-cluster examples:

Static and dynamic cluster using ETCD2.

These examples use [`pivotalrabbitmq/rabbitmq-autocluster` ](https://hub.docker.com/r/pivotalrabbitmq/rabbitmq-autocluster/)docker image

 