### PR TITLE
Add consul tag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,8 +376,10 @@ The following settings impact the configuration of the [Consul](http://consul.io
   <dd>The domain suffix appended to peer node hostname when long node names are used (see above).</dd>
   <dt>Service TTL</dt>
   <dd>Used to specify the Consul <a href="https://www.consul.io/docs/agent/checks.html">health check</a> interval that is used to let Consul know that RabbitMQ is alive an healthy.</dd>
+  <dt>Service Tags</dt>
+  <dd>Used to specify the Consul <a href="https://www.consul.io/api/agent/service.html#tags">service tags</a>. If a cluster name is specified, the tags specified here are added to the cluster name tag</dd>
   <dt>Service unregistration timeout</dt>
-  <dd>How soon should Consul unregister a node that's failing its health check? The value is in second and cannot be lower than 60.</dd>  
+  <dd>How soon should Consul unregister a node that's failing its health check? The value is in second and cannot be lower than 60.</dd>
   <dt>Include nodes that fail Consul health checks?</dt>
   <dd>
     If set to `true`, nodes that fail their health checks with Consul will still be included
@@ -399,6 +401,7 @@ The following settings impact the configuration of the [Consul](http://consul.io
 | Service Auto Address by NIC  | ``CONSUL_SVC_ADDR_NIC``   | ``consul_svc_addr_nic``    | ``string``  |               |
 | Service Port                 | ``CONSUL_SVC_PORT``       | ``consul_svc_port``        | ``integer`` | ``5672``      |
 | Service TTL                  | ``CONSUL_SVC_TTL``        | ``consul_svc_ttl``         | ``integer`` | ``30``        |
+| Service Tags                 | ``CONSUL_SVC_TAGS``       | ``consul_svc_tags``        | ``list``    | ``[]``        |
 | Service unregistration timeout | ``CONSUL_DEREGISTER_AFTER`` | ``consul_deregister_after`` | ``integer`` | ``60``     |
 | Consul Use Longname          | ``CONSUL_USE_LONGNAME``   | ``consul_use_longname``    | ``boolean`` | ``false``     |
 | Consul Domain                | ``CONSUL_DOMAIN``         | ``consul_domain``          | ``string``  | ``consul``    |

--- a/include/autocluster.hrl
+++ b/include/autocluster.hrl
@@ -46,6 +46,7 @@
          {config, consul_svc_addr_nodename,   "CONSUL_SVC_ADDR_NODENAME",    false,  atom,  false},
          {config, consul_svc_port,       "CONSUL_SVC_PORT",        5672,         integer, true},
          {config, consul_svc_ttl,        "CONSUL_SVC_TTL",         30,           integer, false},
+         {config, consul_svc_tags,       "CONSUL_SVC_TAGS",        [],           list, false},
          {config, consul_deregister_after, "CONSUL_DEREGISTER_AFTER", "",        integer,    false}, %% consul deregister_critical_service_after
          {config, consul_use_longname,   "CONSUL_USE_LONGNAME",    false,        atom,    false},
 

--- a/src/autocluster_consul.erl
+++ b/src/autocluster_consul.erl
@@ -538,7 +538,8 @@ registration_body_maybe_add_deregister(Payload, DeregisterAfter) ->
 -spec registration_body_maybe_add_tag(Payload :: list()) -> list().
 registration_body_maybe_add_tag(Payload) ->
   Value = autocluster_config:get(cluster_name),
-  registration_body_maybe_add_tag(Payload, Value).
+  Tags = autocluster_config:get(consul_svc_tags),
+  registration_body_maybe_add_tag(Payload, Value, Tags).
 
 
 %%--------------------------------------------------------------------
@@ -546,14 +547,20 @@ registration_body_maybe_add_tag(Payload) ->
 %% @doc
 %% Check the configured value for the Cluster name, adding it as a
 %% tag if set.
+%% Also add the tags set in CONSUL_SVC_TAGS is set.
 %% @end
 %%--------------------------------------------------------------------
 -spec registration_body_maybe_add_tag(Payload :: list(),
-                                      ClusterName :: string())
+                                      ClusterName :: string(),
+                                      Tags :: list())
     -> list().
-registration_body_maybe_add_tag(Payload, "undefined") -> Payload;
-registration_body_maybe_add_tag(Payload, Cluster) ->
-  lists:append(Payload, [{'Tags', [list_to_atom(Cluster)]}]).
+registration_body_maybe_add_tag(Payload, "undefined", []) -> Payload;
+registration_body_maybe_add_tag(Payload, "undefined", Tags) ->
+  lists:append(Payload, [{'Tags', [list_to_atom(X) || X <- Tags]}]);
+registration_body_maybe_add_tag(Payload, Cluster, []) ->
+  lists:append(Payload, [{'Tags', [list_to_atom(Cluster)]}]);
+registration_body_maybe_add_tag(Payload, Cluster, Tags) ->
+  lists:append(Payload, [{'Tags', [list_to_atom(Cluster)] ++ [list_to_atom(X) || X <- Tags]}]).
 
 
 %%--------------------------------------------------------------------

--- a/test/src/autocluster_config_tests.erl
+++ b/test/src/autocluster_config_tests.erl
@@ -59,6 +59,13 @@ app_envvar_test_() ->
           application:set_env(autocluster, proxy_exclusions, "foo,42,42.5"),
           ?assertEqual(["foo", 42, 42.5], autocluster_config:get(proxy_exclusions))
         end
+      },
+      {
+        "consul tags",
+        fun() ->
+          application:set_env(autocluster, consul_svc_tags, "urlprefix-:5672 proto=tcp, mq, mq server"),
+          ?assertEqual(["urlprefix-:5672 proto=tcp","mq","mq server"], autocluster_config:get(consul_svc_tags))
+        end
       }
     ]
   }.
@@ -120,6 +127,19 @@ os_envvar_test_() ->
         fun() ->
           os:putenv("PROXY_EXCLUSIONS", "foo,42,42.5"),
           ?assertEqual(["foo", 42, 42.5], autocluster_config:get(proxy_exclusions))
+        end
+      },
+      {
+        "consul tags set",
+        fun() ->
+          os:putenv("CONSUL_SVC_TAGS", "urlprefix-:5672 proto=tcp, mq, mq server"),
+          ?assertEqual(["urlprefix-:5672 proto=tcp","mq","mq server"], autocluster_config:get(consul_svc_tags))
+        end
+      },
+      {
+        "consul tags unset",
+        fun() ->
+          ?assertEqual([], autocluster_config:get(consul_svc_tags))
         end
       }
     ]

--- a/test/src/autocluster_consul_tests.erl
+++ b/test/src/autocluster_consul_tests.erl
@@ -32,6 +32,56 @@ build_registration_body_test_() ->
                          {'Status', 'passing'}]}],
         ?assertEqual(Expectation, autocluster_consul:build_registration_body())
        end},
+      {"with tag set", fun() ->
+        os:putenv("CONSUL_SVC_TAGS", "urlprefix-:5672 proto=tcp"),
+        Expectation = [{'ID','rabbitmq'},
+                       {'Name',rabbitmq},
+                       {'Port',5672},
+                       {'Check',
+                        [{'Notes','rabbitmq-autocluster node check'},
+                         {'TTL','30s'},
+                         {'Status', 'passing'}]},
+                       {'Tags',['urlprefix-:5672 proto=tcp']}],
+        ?assertEqual(Expectation, autocluster_consul:build_registration_body())
+       end},
+      {"with tags set", fun() ->
+        os:putenv("CONSUL_SVC_TAGS", "urlprefix-:5672 proto=tcp, mq, mq server"),
+        Expectation = [{'ID','rabbitmq'},
+                       {'Name',rabbitmq},
+                       {'Port',5672},
+                       {'Check',
+                        [{'Notes','rabbitmq-autocluster node check'},
+                         {'TTL','30s'},
+                         {'Status', 'passing'}]},
+                       {'Tags',['urlprefix-:5672 proto=tcp',mq,'mq server']}],
+        ?assertEqual(Expectation, autocluster_consul:build_registration_body())
+       end},
+      {"with tag and cluster name set", fun() ->
+        os:putenv("CLUSTER_NAME", "baruwa"),
+        os:putenv("CONSUL_SVC_TAGS", "urlprefix-:5672 proto=tcp"),
+        Expectation = [{'ID','rabbitmq'},
+                       {'Name',rabbitmq},
+                       {'Port',5672},
+                       {'Check',
+                        [{'Notes','rabbitmq-autocluster node check'},
+                         {'TTL','30s'},
+                         {'Status', 'passing'}]},
+                       {'Tags',['baruwa','urlprefix-:5672 proto=tcp']}],
+        ?assertEqual(Expectation, autocluster_consul:build_registration_body())
+       end},
+      {"with tags and cluster name set", fun() ->
+        os:putenv("CLUSTER_NAME", "baruwa"),
+        os:putenv("CONSUL_SVC_TAGS", "urlprefix-:5672 proto=tcp, mq, mq server"),
+        Expectation = [{'ID','rabbitmq'},
+                       {'Name',rabbitmq},
+                       {'Port',5672},
+                       {'Check',
+                        [{'Notes','rabbitmq-autocluster node check'},
+                         {'TTL','30s'},
+                         {'Status', 'passing'}]},
+                       {'Tags',['baruwa','urlprefix-:5672 proto=tcp',mq,'mq server']}],
+        ?assertEqual(Expectation, autocluster_consul:build_registration_body())
+       end},
       {"with ttl set", fun() ->
         os:putenv("CONSUL_SVC_TTL", "269"),
         Expectation = [{'ID','rabbitmq'},


### PR DESCRIPTION
Adds support for tags to enable use of consul configured load balancers such as fabio