### PR TITLE
Support consul 1.x.x

### DIFF
--- a/src/autocluster_consul.erl
+++ b/src/autocluster_consul.erl
@@ -183,7 +183,7 @@ send_health_check_pass() ->
                              autocluster_config:get(consul_host),
                              autocluster_config:get(consul_port),
                              [v1, agent, check, pass, Service],
-                             maybe_add_acl([])) of
+                             maybe_add_acl([]), "") of
     {ok, []} -> ok;
     {error, "500"} ->
           maybe_re_register(wait_nodelist());
@@ -234,7 +234,7 @@ unregister() ->
                              autocluster_config:get(consul_host),
                              autocluster_config:get(consul_port),
                              [v1, agent, service, deregister, Service],
-                             maybe_add_acl([])) of
+                             maybe_add_acl([]), "") of
     {ok, _} -> ok;
     Error   -> Error
   end.

--- a/src/autocluster_consul.erl
+++ b/src/autocluster_consul.erl
@@ -60,7 +60,7 @@ nodelist() ->
 -spec maybe_create_session(string(), pos_integer()) -> {ok,string()} | {error, string()}.
 maybe_create_session(Who, N) when N > 0 ->
     case create_session(Who, autocluster_config:get(consul_svc_ttl)) of
-        {error, "500"} -> 
+        {error, "500"} ->
 	    autocluster_log:warning("Error 500 while creating a Consul session, " ++
 					" ~p retries left", [N]),
 	    timer:sleep(2000),
@@ -119,7 +119,7 @@ unlock(SessionId) ->
 register() ->
   case registration_body() of
     {ok, Body} ->
-      case autocluster_httpc:post(autocluster_config:get(consul_scheme),
+      case autocluster_httpc:put(autocluster_config:get(consul_scheme),
                                   autocluster_config:get(consul_host),
                                   autocluster_config:get(consul_port),
                                   [v1, agent, service, register],
@@ -179,7 +179,7 @@ lock(SessionId, _, EndTime) ->
 -spec send_health_check_pass() -> ok.
 send_health_check_pass() ->
   Service = string:join(["service", service_id()], ":"),
-  case autocluster_httpc:get(autocluster_config:get(consul_scheme),
+  case autocluster_httpc:put(autocluster_config:get(consul_scheme),
                              autocluster_config:get(consul_host),
                              autocluster_config:get(consul_port),
                              [v1, agent, check, pass, Service],
@@ -230,7 +230,7 @@ wait_nodelist(N) ->
 -spec unregister() -> ok | {error, Reason :: string()}.
 unregister() ->
   Service = service_id(),
-  case autocluster_httpc:get(autocluster_config:get(consul_scheme),
+  case autocluster_httpc:put(autocluster_config:get(consul_scheme),
                              autocluster_config:get(consul_host),
                              autocluster_config:get(consul_port),
                              [v1, agent, service, deregister, Service],


### PR DESCRIPTION
## Add support for Consul 1.x.x

Consul 1.x.x starting 1.0.0 enforces HTTP verbs.

* https://www.consul.io/docs/upgrade-specific.html#http-verbs-are-enforced-in-many-http-apis

Currently some methods in the plugin code use incorrect verbs.

The pull requests updates the methods to use the correct HTTP verbs.

## Types of Changes

- [X] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [X] Cosmetics (whitespace, appearance)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in related repositories

## Further Comments

I have tested with `consul` `0.9.3` and `1.0.0` to ensure that the changes to not break versions < `1.0.0`