### PR TITLE
Pass consul token as a header

### DIFF
--- a/src/autocluster_consul.erl
+++ b/src/autocluster_consul.erl
@@ -45,7 +45,9 @@ nodelist() ->
                              autocluster_config:get(consul_port),
                              [v1, health, service,
                               autocluster_config:get(consul_svc)],
-                             node_list_qargs()) of
+                             node_list_qargs(),
+                             maybe_add_acl([]),
+                             []) of
     {ok, Nodes} ->
       {ok, extract_nodes(
              filter_nodes(Nodes,
@@ -123,7 +125,9 @@ register() ->
                                   autocluster_config:get(consul_host),
                                   autocluster_config:get(consul_port),
                                   [v1, agent, service, register],
-                                  maybe_add_acl([]), Body) of
+                                  [],
+                                  maybe_add_acl([]),
+                                  Body) of
         {ok, _} ->
               case autocluster_config:get(consul_svc_ttl) of
                   undefined -> ok;
@@ -183,7 +187,9 @@ send_health_check_pass() ->
                              autocluster_config:get(consul_host),
                              autocluster_config:get(consul_port),
                              [v1, agent, check, pass, Service],
-                             maybe_add_acl([]), "") of
+                             [],
+                             maybe_add_acl([]),
+                             "") of
     {ok, []} -> ok;
     {error, "500"} ->
           maybe_re_register(wait_nodelist());
@@ -234,7 +240,9 @@ unregister() ->
                              autocluster_config:get(consul_host),
                              autocluster_config:get(consul_port),
                              [v1, agent, service, deregister, Service],
-                             maybe_add_acl([]), "") of
+                             [],
+                             maybe_add_acl([]),
+                             "") of
     {ok, _} -> ok;
     Error   -> Error
   end.
@@ -243,14 +251,14 @@ unregister() ->
 %%--------------------------------------------------------------------
 %% @private
 %% @doc
-%% If configured, add the ACL token to the query arguments.
+%% If configured, add the ACL token to the headers.
 %% @end
 %%--------------------------------------------------------------------
 -spec maybe_add_acl(QArgs :: list()) -> list().
 maybe_add_acl(QArgs) ->
   case autocluster_config:get(consul_acl_token) of
     "undefined" -> QArgs;
-    ACL         -> lists:append(QArgs, [{token, ACL}])
+    ACL         -> lists:append(QArgs, [{"X-Consul-Token", ACL}])
   end.
 
 
@@ -324,7 +332,7 @@ extract_nodes([{struct, H}|T], Nodes) ->
 %%--------------------------------------------------------------------
 -spec node_list_qargs() -> list().
 node_list_qargs() ->
-  maybe_add_acl(node_list_qargs(autocluster_config:get(cluster_name))).
+  node_list_qargs(autocluster_config:get(cluster_name)).
 
 
 %%--------------------------------------------------------------------
@@ -714,7 +722,7 @@ get_session_id({struct, [{_, ID} | _]}) -> binary:bin_to_list(ID).
 %%--------------------------------------------------------------------
 -spec create_session(string(), pos_integer()) -> {ok, string()} | {error, Reason::string()}.
 create_session(Name, TTL) ->
-    case consul_session_create(maybe_add_acl([]),
+    case consul_session_create([], maybe_add_acl([]),
                                [{'Name', list_to_atom(Name)},
                                 {'TTL', list_to_atom(service_ttl(TTL))}]) of
         {ok, Response} ->
@@ -731,7 +739,7 @@ create_session(Name, TTL) ->
 %%--------------------------------------------------------------------
 -spec session_ttl_update_callback(string()) -> string().
 session_ttl_update_callback(SessionId) ->
-    _ = consul_session_renew(SessionId, maybe_add_acl([])),
+    _ = consul_session_renew(SessionId, [], maybe_add_acl([])),
     SessionId.
 
 
@@ -810,7 +818,7 @@ startup_lock_path() ->
 %%--------------------------------------------------------------------
 -spec acquire_lock(string()) -> {ok, term()} | {error, string()}.
 acquire_lock(SessionId) ->
-    consul_kv_write(startup_lock_path(), maybe_add_acl([{acquire, SessionId}]), []).
+    consul_kv_write(startup_lock_path(), [{acquire, SessionId}], maybe_add_acl([]), []).
 
 
 %%--------------------------------------------------------------------
@@ -821,7 +829,7 @@ acquire_lock(SessionId) ->
 %%--------------------------------------------------------------------
 -spec release_lock(string()) -> {ok, term()} | {error, string()}.
 release_lock(SessionId) ->
-    consul_kv_write(startup_lock_path(), maybe_add_acl([{release, SessionId}]), []).
+    consul_kv_write(startup_lock_path(), [{release, SessionId}], maybe_add_acl([]), []).
 
 
 %%--------------------------------------------------------------------
@@ -834,7 +842,7 @@ release_lock(SessionId) ->
 %%--------------------------------------------------------------------
 -spec get_lock_status() -> {ok, term()} | {error, string()}.
 get_lock_status() ->
-    case consul_kv_read(startup_lock_path(), maybe_add_acl([])) of
+    case consul_kv_read(startup_lock_path(), [], maybe_add_acl([])) of
         {ok, [{struct, KeyData} | _]} ->
             SessionHeld = proplists:get_value(<<"Session">>, KeyData) =/= undefined,
             ModifyIndex = proplists:get_value(<<"ModifyIndex">>, KeyData),
@@ -854,8 +862,8 @@ get_lock_status() ->
 wait_for_lock_release(false, _, _) -> ok;
 wait_for_lock_release(_, Index, Wait) ->
     case consul_kv_read(startup_lock_path(),
-                        maybe_add_acl([{index, Index},
-                                       {wait, service_ttl(Wait)}])) of
+                        [{index, Index}, {wait, service_ttl(Wait)}],
+                        maybe_add_acl([])) of
         {ok, _}          -> ok;
         {error, _} = Err -> Err
     end.
@@ -870,14 +878,18 @@ wait_for_lock_release(_, Index, Wait) ->
 %% Read KV store key value
 %% @end
 %%--------------------------------------------------------------------
--spec consul_kv_read(Path, Query) -> {ok, term()} | {error, string()} when
+-spec consul_kv_read(Path, Query, Headers) -> {ok, term()} | {error, string()} when
       Path :: [autocluster_httpc:path_component()],
-      Query :: [autocluster_httpc:query_component()].
-consul_kv_read(Path, Query) ->
+      Query :: [autocluster_httpc:query_component()],
+      Headers :: [{string(), string()}].
+consul_kv_read(Path, Query, Headers) ->
     autocluster_httpc:get(autocluster_config:get(consul_scheme),
                           autocluster_config:get(consul_host),
                           autocluster_config:get(consul_port),
-                          [v1, kv] ++ Path, Query).
+                          [v1, kv] ++ Path,
+                          Query,
+                          Headers,
+                          []).
 
 
 %%--------------------------------------------------------------------
@@ -886,17 +898,21 @@ consul_kv_read(Path, Query) ->
 %% Write KV store key value
 %% @end
 %%--------------------------------------------------------------------
--spec consul_kv_write(Path, Query, Body) -> {ok, term()} | {error, string()} when
+-spec consul_kv_write(Path, Query, Headers, Body) -> {ok, term()} | {error, string()} when
       Path :: [autocluster_httpc:path_component()],
       Query :: [autocluster_httpc:query_component()],
+      Headers :: [{string(), string()}],
       Body :: term().
-consul_kv_write(Path, Query, Body) ->
+consul_kv_write(Path, Query, Headers, Body) ->
     case serialize_json_body(Body) of
         {ok, Serialized} ->
             autocluster_httpc:put(autocluster_config:get(consul_scheme),
                                   autocluster_config:get(consul_host),
                                   autocluster_config:get(consul_port),
-                                  [v1, kv] ++ Path, Query, Serialized);
+                                  [v1, kv] ++ Path,
+                                  Query,
+                                  Headers,
+                                  Serialized);
         {error, _} = Err ->
             Err
     end.
@@ -928,16 +944,20 @@ consul_kv_write(Path, Query, Body) ->
 %% Create session
 %% @end
 %%--------------------------------------------------------------------
--spec consul_session_create(Query, Body) -> {ok, term()} | {error, Reason::string()} when
+-spec consul_session_create(Query, Headers, Body) -> {ok, term()} | {error, Reason::string()} when
       Query :: [autocluster_httpc:query_component()],
+      Headers :: [{string(), string()}],
       Body :: term().
-consul_session_create(Query, Body) ->
+consul_session_create(Query, Headers, Body) ->
       case serialize_json_body(Body) of
           {ok, Serialized} ->
               autocluster_httpc:put(autocluster_config:get(consul_scheme),
                                     autocluster_config:get(consul_host),
                                     autocluster_config:get(consul_port),
-                                    [v1, session, create], Query, Serialized);
+                                    [v1, session, create],
+                                    Query,
+                                    Headers,
+                                    Serialized);
           {error, _} = Err ->
               Err
       end.
@@ -949,9 +969,12 @@ consul_session_create(Query, Body) ->
 %% Renew session TTL
 %% @end
 %%--------------------------------------------------------------------
--spec consul_session_renew(string(), [autocluster_httpc:query_component()]) -> {ok, term()} | {error, string()}.
-consul_session_renew(SessionId, Query) ->
+-spec consul_session_renew(string(), [autocluster_httpc:query_component()], [{string(), string()}]) -> {ok, term()} | {error, string()}.
+consul_session_renew(SessionId, Query, Headers) ->
   autocluster_httpc:put(autocluster_config:get(consul_scheme),
                         autocluster_config:get(consul_host),
                         autocluster_config:get(consul_port),
-                        [v1, session, renew, list_to_atom(SessionId)], Query, []).
+                        [v1, session, renew, list_to_atom(SessionId)],
+                        Query,
+                        Headers,
+                        []).

--- a/src/autocluster_httpc.erl
+++ b/src/autocluster_httpc.erl
@@ -13,7 +13,8 @@
          get/5,
          get/7,
          post/6,
-         put/6]).
+         put/6,
+         put/7]).
 
 %% Export all for unit tests
 -ifdef(TEST).
@@ -167,6 +168,27 @@ put(Scheme, Host, Port, Path, Args, Body) ->
   URL = build_uri(Scheme, Host, Port, Path, Args),
   autocluster_log:debug("PUT ~s [~p]", [URL, Body]),
   Response = httpc:request(put, {URL, [], ?CONTENT_URLENCODED, Body}, [], []),
+  autocluster_log:debug("Response: [~p]", [Response]),
+  parse_response(Response).
+
+
+%% @public
+%% @spec put(Scheme, Host, Port, Path, Args, Headers, Body) -> Result
+%% @where Scheme  = string(),
+%%        Host    = string(),
+%%        Port    = integer(),
+%%        Path    = string(),
+%%        Args    = proplist(),
+%%        Headers = proplist(),
+%%        Body    = string(),
+%%        Result  = {ok, mixed}|{error, Reason::string()}
+%% @doc Perform a HTTP PUT request
+%% @end
+%%
+put(Scheme, Host, Port, Path, Args, Headers, Body) ->
+  URL = build_uri(Scheme, Host, Port, Path, Args),
+  autocluster_log:debug("PUT ~s [~p] [~p]", [URL, Headers, Body]),
+  Response = httpc:request(put, {URL, Headers, ?CONTENT_URLENCODED, Body}, [], []),
   autocluster_log:debug("Response: [~p]", [Response]),
   parse_response(Response).
 

--- a/test/src/autocluster_consul_tests.erl
+++ b/test/src/autocluster_consul_tests.erl
@@ -154,12 +154,14 @@ nodelist_test_() ->
       {"default values",
         fun() ->
           meck:expect(autocluster_httpc, get,
-            fun(Scheme, Host, Port, Path, Args) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("localhost", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, health, service, "rabbitmq"], Path),
               ?assertEqual([passing], Args),
+              ?assertEqual([], Headers),
+              ?assertEqual([], HttpOpts),
               {error, "testing"}
             end),
           ?assertEqual({error, "testing"}, autocluster_consul:nodelist()),
@@ -168,12 +170,14 @@ nodelist_test_() ->
       {"without token",
         fun() ->
           meck:expect(autocluster_httpc, get,
-            fun(Scheme, Host, Port, Path, Args) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts) ->
               ?assertEqual("https", Scheme),
               ?assertEqual("consul.service.consul", Host),
               ?assertEqual(8501, Port),
               ?assertEqual([v1, health, service, "rabbit"], Path),
               ?assertEqual([passing], Args),
+              ?assertEqual([], Headers),
+              ?assertEqual([], HttpOpts),
               {error, "testing"}
             end),
           os:putenv("CONSUL_SCHEME", "https"),
@@ -186,12 +190,14 @@ nodelist_test_() ->
       {"with token",
         fun() ->
           meck:expect(autocluster_httpc, get,
-            fun(Scheme, Host, Port, Path, Args) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("consul.service.consul", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, health, service, "rabbitmq"], Path),
-              ?assertEqual([passing, {token, "token-value"}], Args),
+              ?assertEqual([passing], Args),
+              ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
+              ?assertEqual([], HttpOpts),
               {error, "testing"}
             end),
           os:putenv("CONSUL_HOST", "consul.service.consul"),
@@ -203,12 +209,14 @@ nodelist_test_() ->
       {"with cluster name",
         fun() ->
           meck:expect(autocluster_httpc, get,
-            fun(Scheme, Host, Port, Path, Args) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("localhost", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, health, service, "rabbitmq"], Path),
               ?assertEqual([passing, {tag,"bob"}], Args),
+              ?assertEqual([], Headers),
+              ?assertEqual([], HttpOpts),
               {error, "testing"}
             end),
           os:putenv("CLUSTER_NAME", "bob"),
@@ -218,12 +226,14 @@ nodelist_test_() ->
       {"with cluster name and token",
         fun() ->
           meck:expect(autocluster_httpc, get,
-            fun(Scheme, Host, Port, Path, Args) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("localhost", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, health, service, "rabbitmq"], Path),
-              ?assertEqual([passing, {tag,"bob"}, {token, "token-value"}], Args),
+              ?assertEqual([passing, {tag,"bob"}], Args),
+              ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
+              ?assertEqual([], HttpOpts),
               {error, "testing"}
             end),
           os:putenv("CLUSTER_NAME", "bob"),
@@ -234,7 +244,7 @@ nodelist_test_() ->
       {"return result",
         fun() ->
           meck:expect(autocluster_httpc, get,
-            fun(_, _, _, _, _) ->
+            fun(_, _, _, _, _, _, _) ->
               Body = "[{\"Node\": {\"Node\": \"rabbit2.internal.domain\", \"Address\": \"10.20.16.160\"}, \"Checks\": [{\"Node\": \"rabbit2.internal.domain\", \"CheckID\": \"service:rabbitmq\", \"Name\": \"Service \'rabbitmq\' check\", \"ServiceName\": \"rabbitmq\", \"Notes\": \"Connect to the port internally every 30 seconds\", \"Status\": \"passing\", \"ServiceID\": \"rabbitmq\", \"Output\": \"\"}, {\"Node\": \"rabbit2.internal.domain\", \"CheckID\": \"serfHealth\", \"Name\": \"Serf Health Status\", \"ServiceName\": \"\", \"Notes\": \"\", \"Status\": \"passing\", \"ServiceID\": \"\", \"Output\": \"Agent alive and reachable\"}], \"Service\": {\"Address\": \"\", \"Port\": 5672, \"ID\": \"rabbitmq\", \"Service\": \"rabbitmq\", \"Tags\": [\"amqp\"]}}, {\"Node\": {\"Node\": \"rabbit1.internal.domain\", \"Address\": \"10.20.16.159\"}, \"Checks\": [{\"Node\": \"rabbit1.internal.domain\", \"CheckID\": \"service:rabbitmq\", \"Name\": \"Service \'rabbitmq\' check\", \"ServiceName\": \"rabbitmq\", \"Notes\": \"Connect to the port internally every 30 seconds\", \"Status\": \"passing\", \"ServiceID\": \"rabbitmq\", \"Output\": \"\"}, {\"Node\": \"rabbit1.internal.domain\", \"CheckID\": \"serfHealth\", \"Name\": \"Serf Health Status\", \"ServiceName\": \"\", \"Notes\": \"\", \"Status\": \"passing\", \"ServiceID\": \"\", \"Output\": \"Agent alive and reachable\"}], \"Service\": {\"Address\": \"\", \"Port\": 5672, \"ID\": \"rabbitmq\", \"Service\": \"rabbitmq\", \"Tags\": [\"amqp\"]}}]",
               rabbit_misc:json_decode(Body)
             end),
@@ -245,7 +255,7 @@ nodelist_test_() ->
       {"return result with consul long name",
         fun() ->
           meck:expect(autocluster_httpc, get,
-            fun(_, _, _, _, _) ->
+            fun(_, _, _, _, _, _, _) ->
               Body = "[{\"Node\": {\"Node\": \"rabbit2\", \"Address\": \"10.20.16.160\"}, \"Checks\": [{\"Node\": \"rabbit2\", \"CheckID\": \"service:rabbitmq\", \"Name\": \"Service \'rabbitmq\' check\", \"ServiceName\": \"rabbitmq\", \"Notes\": \"Connect to the port internally every 30 seconds\", \"Status\": \"passing\", \"ServiceID\": \"rabbitmq\", \"Output\": \"\"}, {\"Node\": \"rabbit2\", \"CheckID\": \"serfHealth\", \"Name\": \"Serf Health Status\", \"ServiceName\": \"\", \"Notes\": \"\", \"Status\": \"passing\", \"ServiceID\": \"\", \"Output\": \"Agent alive and reachable\"}], \"Service\": {\"Address\": \"\", \"Port\": 5672, \"ID\": \"rabbitmq\", \"Service\": \"rabbitmq\", \"Tags\": [\"amqp\"]}}, {\"Node\": {\"Node\": \"rabbit1\", \"Address\": \"10.20.16.159\"}, \"Checks\": [{\"Node\": \"rabbit1\", \"CheckID\": \"service:rabbitmq\", \"Name\": \"Service \'rabbitmq\' check\", \"ServiceName\": \"rabbitmq\", \"Notes\": \"Connect to the port internally every 30 seconds\", \"Status\": \"passing\", \"ServiceID\": \"rabbitmq\", \"Output\": \"\"}, {\"Node\": \"rabbit1\", \"CheckID\": \"serfHealth\", \"Name\": \"Serf Health Status\", \"ServiceName\": \"\", \"Notes\": \"\", \"Status\": \"passing\", \"ServiceID\": \"\", \"Output\": \"Agent alive and reachable\"}], \"Service\": {\"Address\": \"\", \"Port\": 5672, \"ID\": \"rabbitmq\", \"Service\": \"rabbitmq\", \"Tags\": [\"amqp\"]}}]",
               rabbit_misc:json_decode(Body)
             end),
@@ -257,7 +267,7 @@ nodelist_test_() ->
       {"return result with long name and custom domain",
         fun() ->
           meck:expect(autocluster_httpc, get,
-            fun(_, _, _, _, _) ->
+            fun(_, _, _, _, _, _, _) ->
               Body = "[{\"Node\": {\"Node\": \"rabbit2\", \"Address\": \"10.20.16.160\"}, \"Checks\": [{\"Node\": \"rabbit2\", \"CheckID\": \"service:rabbitmq\", \"Name\": \"Service \'rabbitmq\' check\", \"ServiceName\": \"rabbitmq\", \"Notes\": \"Connect to the port internally every 30 seconds\", \"Status\": \"passing\", \"ServiceID\": \"rabbitmq\", \"Output\": \"\"}, {\"Node\": \"rabbit2\", \"CheckID\": \"serfHealth\", \"Name\": \"Serf Health Status\", \"ServiceName\": \"\", \"Notes\": \"\", \"Status\": \"passing\", \"ServiceID\": \"\", \"Output\": \"Agent alive and reachable\"}], \"Service\": {\"Address\": \"\", \"Port\": 5672, \"ID\": \"rabbitmq\", \"Service\": \"rabbitmq\", \"Tags\": [\"amqp\"]}}, {\"Node\": {\"Node\": \"rabbit1\", \"Address\": \"10.20.16.159\"}, \"Checks\": [{\"Node\": \"rabbit1\", \"CheckID\": \"service:rabbitmq\", \"Name\": \"Service \'rabbitmq\' check\", \"ServiceName\": \"rabbitmq\", \"Notes\": \"Connect to the port internally every 30 seconds\", \"Status\": \"passing\", \"ServiceID\": \"rabbitmq\", \"Output\": \"\"}, {\"Node\": \"rabbit1\", \"CheckID\": \"serfHealth\", \"Name\": \"Serf Health Status\", \"ServiceName\": \"\", \"Notes\": \"\", \"Status\": \"passing\", \"ServiceID\": \"\", \"Output\": \"Agent alive and reachable\"}], \"Service\": {\"Address\": \"\", \"Port\": 5672, \"ID\": \"rabbitmq\", \"Service\": \"rabbitmq\", \"Tags\": [\"amqp\"]}}]",
               rabbit_misc:json_decode(Body)
             end),
@@ -270,7 +280,7 @@ nodelist_test_() ->
       {"return result with srv address",
         fun() ->
           meck:expect(autocluster_httpc, get,
-            fun(_, _, _, _, _) ->
+            fun(_, _, _, _, _, _, _) ->
               Body = "[{\"Node\": {\"Node\": \"rabbit2.internal.domain\", \"Address\": \"10.20.16.160\"}, \"Checks\": [{\"Node\": \"rabbit2.internal.domain\", \"CheckID\": \"service:rabbitmq\", \"Name\": \"Service \'rabbitmq\' check\", \"ServiceName\": \"rabbitmq\", \"Notes\": \"Connect to the port internally every 30 seconds\", \"Status\": \"passing\", \"ServiceID\": \"rabbitmq:172.172.16.4.50\", \"Output\": \"\"}, {\"Node\": \"rabbit2.internal.domain\", \"CheckID\": \"serfHealth\", \"Name\": \"Serf Health Status\", \"ServiceName\": \"\", \"Notes\": \"\", \"Status\": \"passing\", \"ServiceID\": \"\", \"Output\": \"Agent alive and reachable\"}], \"Service\": {\"Address\": \"172.16.4.51\", \"Port\": 5672, \"ID\": \"rabbitmq:172.16.4.51\", \"Service\": \"rabbitmq\", \"Tags\": [\"amqp\"]}}, {\"Node\": {\"Node\": \"rabbit1.internal.domain\", \"Address\": \"10.20.16.159\"}, \"Checks\": [{\"Node\": \"rabbit1.internal.domain\", \"CheckID\": \"service:rabbitmq\", \"Name\": \"Service \'rabbitmq\' check\", \"ServiceName\": \"rabbitmq\", \"Notes\": \"Connect to the port internally every 30 seconds\", \"Status\": \"passing\", \"ServiceID\": \"rabbitmq\", \"Output\": \"\"}, {\"Node\": \"rabbit1.internal.domain\", \"CheckID\": \"serfHealth\", \"Name\": \"Serf Health Status\", \"ServiceName\": \"\", \"Notes\": \"\", \"Status\": \"passing\", \"ServiceID\": \"\", \"Output\": \"Agent alive and reachable\"}], \"Service\": {\"Address\": \"172.172.16.51\", \"Port\": 5672, \"ID\": \"rabbitmq:172.172.16.51\", \"Service\": \"rabbitmq\", \"Tags\": [\"amqp\"]}}]",
               rabbit_misc:json_decode(Body)
             end),
@@ -281,9 +291,9 @@ nodelist_test_() ->
       {"return result with warnings allowed",
         fun() ->
           meck:expect(autocluster_httpc, get,
-            fun(_, _, _, _, []) ->
+            fun(_, _, _, _, [], _, _) ->
                     rabbit_misc:json_decode(with_warnings());
-               (_, _, _, _, [passing]) ->
+               (_, _, _, _, [passing], _, _) ->
                     rabbit_misc:json_decode(without_warnings())
             end),
           os:putenv("CONSUL_INCLUDE_NODES_WITH_WARNINGS", "true"),
@@ -294,9 +304,9 @@ nodelist_test_() ->
       {"return result with no warnings allowed",
         fun() ->
           meck:expect(autocluster_httpc, get,
-            fun(_, _, _, _, []) ->
+            fun(_, _, _, _, [], _, _) ->
                     rabbit_misc:json_decode(with_warnings());
-               (_, _, _, _, [passing]) ->
+               (_, _, _, _, [passing], _, _) ->
                     rabbit_misc:json_decode(without_warnings())
             end),
           Expectation = {ok,['rabbit@172.16.4.51', 'rabbit@172.172.16.51']},
@@ -324,12 +334,13 @@ register_test_() ->
         fun() ->
           meck:expect(autocluster_log, debug, fun(_Message) -> ok end),
           meck:expect(autocluster_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("localhost", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, agent, service, register], Path),
               ?assertEqual([], Args),
+              ?assertEqual([], Headers),
               Expect = <<"{\"ID\":\"rabbitmq\",\"Name\":\"rabbitmq\",\"Port\":5672,\"Check\":{\"Notes\":\"rabbitmq-autocluster node check\",\"TTL\":\"30s\",\"Status\":\"passing\"}}">>,
               ?assertEqual(Expect, Body),
               {ok, []}
@@ -349,12 +360,13 @@ register_test_() ->
       {"with cluster name",
         fun() ->
           meck:expect(autocluster_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("localhost", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, agent, service, register], Path),
               ?assertEqual([], Args),
+              ?assertEqual([], Headers),
               Expect = <<"{\"ID\":\"rabbitmq\",\"Name\":\"rabbitmq\",\"Port\":5672,\"Check\":{\"Notes\":\"rabbitmq-autocluster node check\",\"TTL\":\"30s\",\"Status\":\"passing\"},\"Tags\":[\"test-rabbit\"]}">>,
               ?assertEqual(Expect, Body),
               {ok, []}
@@ -365,12 +377,13 @@ register_test_() ->
         end},
       {"without token",  fun() ->
           meck:expect(autocluster_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
               ?assertEqual("https", Scheme),
               ?assertEqual("consul.service.consul", Host),
               ?assertEqual(8501, Port),
               ?assertEqual([v1, agent, service, register], Path),
               ?assertEqual([], Args),
+              ?assertEqual([], Headers),
               Expect = <<"{\"ID\":\"rabbit:10.0.0.1\",\"Name\":\"rabbit\",\"Address\":\"10.0.0.1\",\"Port\":5671,\"Check\":{\"Notes\":\"rabbitmq-autocluster node check\",\"TTL\":\"30s\",\"Status\":\"passing\"}}">>,
               ?assertEqual(Expect, Body),
               {ok, []}
@@ -387,12 +400,13 @@ register_test_() ->
       {"with token",
         fun() ->
           meck:expect(autocluster_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("consul.service.consul", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, agent, service, register], Path),
-              ?assertEqual([{token, "token-value"}], Args),
+              ?assertEqual([], Args),
+              ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
               Expect = <<"{\"ID\":\"rabbitmq\",\"Name\":\"rabbitmq\",\"Port\":5672,\"Check\":{\"Notes\":\"rabbitmq-autocluster node check\",\"TTL\":\"30s\",\"Status\":\"passing\"}}">>,
               ?assertEqual(Expect, Body),
               {ok, []}
@@ -408,12 +422,13 @@ register_test_() ->
           meck:expect(autocluster_util, node_hostname, fun(true) -> "bob.consul.node";
                                                           (false) -> "bob" end),
           meck:expect(autocluster_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("consul.service.consul", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, agent, service, register], Path),
-              ?assertEqual([{token, "token-value"}], Args),
+              ?assertEqual([], Args),
+              ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
               Expect = <<"{\"ID\":\"rabbitmq:bob\",\"Name\":\"rabbitmq\",\"Address\":\"bob\",\"Port\":5672,\"Check\":{\"Notes\":\"rabbitmq-autocluster node check\",\"TTL\":\"30s\",\"Status\":\"passing\"}}">>,
               ?assertEqual(Expect, Body),
               {ok, []}
@@ -431,12 +446,13 @@ register_test_() ->
           meck:expect(autocluster_util, node_hostname, fun(true) -> "bob.consul.node";
                                                           (false) -> "bob" end),
           meck:expect(autocluster_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("consul.service.consul", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, agent, service, register], Path),
-              ?assertEqual([{token, "token-value"}], Args),
+              ?assertEqual([], Args),
+              ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
               Expect = <<"{\"ID\":\"rabbitmq:bob.consul.node\",\"Name\":\"rabbitmq\",\"Address\":\"bob.consul.node\",\"Port\":5672,\"Check\":{\"Notes\":\"rabbitmq-autocluster node check\",\"TTL\":\"30s\",\"Status\":\"passing\"}}">>,
               ?assertEqual(Expect, Body),
               {ok, []}
@@ -458,12 +474,13 @@ register_test_() ->
               {ok, "172.16.4.50"}
             end),
           meck:expect(autocluster_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("consul.service.consul", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, agent, service, register], Path),
-              ?assertEqual([{token, "token-value"}], Args),
+              ?assertEqual([], Args),
+              ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
               Expect = <<"{\"ID\":\"rabbitmq:172.16.4.50\",\"Name\":\"rabbitmq\",\"Address\":\"172.16.4.50\",\"Port\":5672,\"Check\":{\"Notes\":\"rabbitmq-autocluster node check\",\"TTL\":\"30s\",\"Status\":\"passing\"}}">>,
               ?assertEqual(Expect, Body),
               {ok, []}
@@ -481,7 +498,7 @@ register_test_() ->
         meck:expect(timer, apply_interval, fun(_, _, _, _) ->
           {error, "should not be called"}
          end),
-        meck:expect(autocluster_httpc, put, fun (_, _, _, _, _, _) -> {ok, []} end),
+        meck:expect(autocluster_httpc, put, fun (_, _, _, _, _, _, _) -> {ok, []} end),
         os:putenv("CONSUL_SVC_TTL", ""),
         ?assertEqual(ok, autocluster_consul:register()),
         ?assert(meck:validate(timer))
@@ -499,7 +516,7 @@ register_failure_test_() ->
         fun() ->
           meck:new(autocluster_httpc),
           meck:expect(autocluster_httpc, put,
-            fun(_Scheme, _Host, _Port, _Path, _Args, _body) ->
+            fun(_Scheme, _Host, _Port, _Path, _Args, _Headers, _body) ->
               {error, "testing"}
             end),
           ?assertEqual({error, "testing"}, autocluster_consul:register()),
@@ -536,12 +553,13 @@ send_health_check_pass_test_() ->
       {"default values",
         fun() ->
           meck:expect(autocluster_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("localhost", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, agent, check, pass, "service:rabbitmq"], Path),
               ?assertEqual([], Args),
+              ?assertEqual([], Headers),
               ?assertEqual("", Body),
               {ok, []}
             end),
@@ -551,12 +569,13 @@ send_health_check_pass_test_() ->
       {"without token",
         fun() ->
           meck:expect(autocluster_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
               ?assertEqual("https", Scheme),
               ?assertEqual("consul.service.consul", Host),
               ?assertEqual(8501, Port),
               ?assertEqual([v1, agent, check, pass, "service:rabbit"], Path),
               ?assertEqual([], Args),
+              ?assertEqual([], Headers),
               ?assertEqual("", Body),
               {ok, []}
             end),
@@ -569,12 +588,13 @@ send_health_check_pass_test_() ->
         end},
       {"with token", fun() ->
         meck:expect(autocluster_httpc, put,
-          fun(Scheme, Host, Port, Path, Args, Body) ->
+          fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
             ?assertEqual("http", Scheme),
             ?assertEqual("consul.service.consul", Host),
             ?assertEqual(8500, Port),
             ?assertEqual([v1, agent, check, pass, "service:rabbitmq"], Path),
-            ?assertEqual([{token, "token-value"}], Args),
+            ?assertEqual([], Args),
+            ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
             ?assertEqual("", Body),
             {ok, []}
           end),
@@ -589,7 +609,7 @@ send_health_check_pass_test_() ->
           ok
           end),
         meck:expect(autocluster_httpc, put,
-          fun(_Scheme, _Host, _Port, _Path, _Args, _Body) ->
+          fun(_Scheme, _Host, _Port, _Path, _Args, _Headers, _Body) ->
             {error, "testing"}
           end),
         ?assertEqual(ok, autocluster_consul:send_health_check_pass()),
@@ -612,12 +632,13 @@ unregister_test_() ->
     [
       {"default values", fun() ->
         meck:expect(autocluster_httpc, put,
-          fun(Scheme, Host, Port, Path, Args, Body) ->
+          fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
             ?assertEqual("http", Scheme),
             ?assertEqual("localhost", Host),
             ?assertEqual(8500, Port),
             ?assertEqual([v1, agent, service, deregister, "rabbitmq"], Path),
             ?assertEqual([], Args),
+            ?assertEqual([], Headers),
             ?assertEqual("", Body),
             {ok, []}
           end),
@@ -626,12 +647,13 @@ unregister_test_() ->
                          end},
       {"without token", fun() ->
         meck:expect(autocluster_httpc, put,
-          fun(Scheme, Host, Port, Path, Args, Body) ->
+          fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
             ?assertEqual("https", Scheme),
             ?assertEqual("consul.service.consul", Host),
             ?assertEqual(8501, Port),
             ?assertEqual([v1, agent, service, deregister,"rabbit:10.0.0.1"], Path),
             ?assertEqual([], Args),
+            ?assertEqual([], Headers),
             ?assertEqual("", Body),
             {ok, []}
           end),
@@ -646,12 +668,13 @@ unregister_test_() ->
        end},
       {"with token", fun() ->
         meck:expect(autocluster_httpc, put,
-          fun(Scheme, Host, Port, Path, Args, Body) ->
+          fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
             ?assertEqual("http", Scheme),
             ?assertEqual("consul.service.consul", Host),
             ?assertEqual(8500, Port),
             ?assertEqual([v1, agent, service, deregister,"rabbitmq"], Path),
-            ?assertEqual([{token, "token-value"}], Args),
+            ?assertEqual([], Args),
+            ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
             ?assertEqual("", Body),
             {ok, []}
           end),
@@ -663,7 +686,7 @@ unregister_test_() ->
        end},
       {"on error", fun() ->
         meck:expect(autocluster_httpc, put,
-          fun(_Scheme, _Host, _Port, _Path, _Args, _Body) ->
+          fun(_Scheme, _Host, _Port, _Path, _Args, _Headers, _Body) ->
             {error, "testing"}
           end),
         ?assertEqual({error, "testing"}, autocluster_consul:unregister()),
@@ -718,12 +741,13 @@ create_session_test_() ->
       {"without token",
         fun() ->
           meck:expect(autocluster_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("localhost", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, session, create], Path),
               ?assertEqual([], Args),
+              ?assertEqual([], Headers),
               Expect = <<"{\"Name\":\"node-name\",\"TTL\":\"30s\"}">>,
               ?assertEqual(Expect, Body),
               {ok, {struct,[{<<"ID">>, <<"session-id">>}]}}
@@ -734,12 +758,13 @@ create_session_test_() ->
     {"with token",
       fun() ->
         meck:expect(autocluster_httpc, put,
-          fun(Scheme, Host, Port, Path, Args, Body) ->
+          fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
             ?assertEqual("http", Scheme),
             ?assertEqual("localhost", Host),
             ?assertEqual(8500, Port),
             ?assertEqual([v1, session, create], Path),
-            ?assertEqual([{token, "token-value"}], Args),
+            ?assertEqual([], Args),
+            ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
             Expect = <<"{\"Name\":\"node-name\",\"TTL\":\"30s\"}">>,
             ?assertEqual(Expect, Body),
             {ok, {struct,[{<<"ID">>, <<"session-id">>}]}}
@@ -765,12 +790,14 @@ get_lock_status_test_() ->
       {"without session",
         fun() ->
           meck:expect(autocluster_httpc, get,
-            fun(Scheme, Host, Port, Path, Args) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("localhost", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
               ?assertEqual([], Args),
+              ?assertEqual([], Headers),
+              ?assertEqual([], HttpOpts),
               {ok,[{struct,[{<<"LockIndex">>,3},
                             {<<"Key">>,<<"rabbitmq/default/startup_lock">>},
                             {<<"Flags">>,0},
@@ -785,12 +812,14 @@ get_lock_status_test_() ->
       {"with session",
         fun() ->
           meck:expect(autocluster_httpc, get,
-            fun(Scheme, Host, Port, Path, Args) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("localhost", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
               ?assertEqual([], Args),
+              ?assertEqual([], Headers),
+              ?assertEqual([], HttpOpts),
               {ok,[{struct,[{<<"LockIndex">>,3},
                             {<<"Key">>,<<"rabbitmq/default/startup_lock">>},
                             {<<"Flags">>,0},
@@ -804,12 +833,14 @@ get_lock_status_test_() ->
         {"with token",
           fun() ->
             meck:expect(autocluster_httpc, get,
-              fun(Scheme, Host, Port, Path, Args) ->
+              fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts) ->
                 ?assertEqual("http", Scheme),
                 ?assertEqual("localhost", Host),
                 ?assertEqual(8500, Port),
                 ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
-                ?assertEqual([{token, "token-value"}], Args),
+                ?assertEqual([], Args),
+                ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
+                ?assertEqual([], HttpOpts),
                 {ok,[{struct,[{<<"LockIndex">>,3},
                               {<<"Key">>,<<"rabbitmq/default/startup_lock">>},
                               {<<"Flags">>,0},
@@ -837,12 +868,14 @@ wait_for_lock_release_with_session_test_() ->
       {"without token",
         fun() ->
           meck:expect(autocluster_httpc, get,
-            fun(Scheme, Host, Port, Path, Args) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("localhost", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
               ?assertEqual([{index, 42}, {wait, "300s"}], Args),
+              ?assertEqual([], Headers),
+              ?assertEqual([], HttpOpts),
               {ok, []}
             end),
           ?assertEqual(ok, autocluster_consul:wait_for_lock_release(true, 42, 300)),
@@ -851,12 +884,14 @@ wait_for_lock_release_with_session_test_() ->
       {"with token",
         fun() ->
           meck:expect(autocluster_httpc, get,
-            fun(Scheme, Host, Port, Path, Args) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("localhost", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
-              ?assertEqual([{index, 42}, {wait, "300s"}, {token, "token-value"}], Args),
+              ?assertEqual([{index, 42}, {wait, "300s"}], Args),
+              ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
+              ?assertEqual([], HttpOpts),
               {ok, []}
             end),
           os:putenv("CONSUL_ACL_TOKEN", "token-value"),
@@ -882,12 +917,13 @@ acquire_lock_test_() ->
       {"successfully acquired",
         fun() ->
           meck:expect(autocluster_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("localhost", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
               ?assertEqual([{acquire, session_id}], Args),
+              ?assertEqual([], Headers),
               ?assertEqual([], Body),
               {ok, true}
             end),
@@ -897,12 +933,13 @@ acquire_lock_test_() ->
         {"not acquired",
           fun() ->
             meck:expect(autocluster_httpc, put,
-              fun(Scheme, Host, Port, Path, Args, Body) ->
+              fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
                 ?assertEqual("http", Scheme),
                 ?assertEqual("localhost", Host),
                 ?assertEqual(8500, Port),
                 ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
                 ?assertEqual([{acquire, session_id}], Args),
+                ?assertEqual([], Headers),
                 ?assertEqual([], Body),
                 {ok, false}
               end),
@@ -912,12 +949,13 @@ acquire_lock_test_() ->
       {"with token",
         fun() ->
           meck:expect(autocluster_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("localhost", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
-              ?assertEqual([{acquire, session_id}, {token, "token-value"}], Args),
+              ?assertEqual([{acquire, session_id}], Args),
+              ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
               ?assertEqual([], Body),
               {ok, true}
             end),
@@ -941,12 +979,13 @@ release_lock_test_() ->
       {"successfully released",
         fun() ->
           meck:expect(autocluster_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("localhost", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
               ?assertEqual([{release, session_id}], Args),
+              ?assertEqual([], Headers),
               ?assertEqual([], Body),
               {ok, true}
             end),
@@ -956,12 +995,13 @@ release_lock_test_() ->
         {"not released",
           fun() ->
             meck:expect(autocluster_httpc, put,
-              fun(Scheme, Host, Port, Path, Args, Body) ->
+              fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
                 ?assertEqual("http", Scheme),
                 ?assertEqual("localhost", Host),
                 ?assertEqual(8500, Port),
                 ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
                 ?assertEqual([{release, session_id}], Args),
+                ?assertEqual([], Headers),
                 ?assertEqual([], Body),
                 {ok, false}
               end),
@@ -971,12 +1011,13 @@ release_lock_test_() ->
       {"with token",
         fun() ->
           meck:expect(autocluster_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("localhost", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, kv, "rabbitmq", "default", "startup_lock"], Path),
-              ?assertEqual([{release, session_id}, {token, "token-value"}], Args),
+              ?assertEqual([{release, session_id}], Args),
+              ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
               ?assertEqual([], Body),
               {ok, true}
             end),
@@ -1000,31 +1041,71 @@ consul_kv_read_test_() ->
       {"default values",
         fun() ->
           meck:expect(autocluster_httpc, get,
-            fun(Scheme, Host, Port, Path, Args) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("localhost", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, kv, "path", "to", "key"], Path),
               ?assertEqual([{acquire, session_id}], Args),
+              ?assertEqual([], Headers),
+              ?assertEqual([], HttpOpts),
               {ok, []}
             end),
-          ?assertEqual({ok, []}, autocluster_consul:consul_kv_read(["path", "to", "key"], [{acquire, session_id}])),
+          ?assertEqual({ok, []}, autocluster_consul:consul_kv_read(["path", "to", "key"], [{acquire, session_id}], autocluster_consul:maybe_add_acl([]))),
           ?assert(meck:validate(autocluster_httpc))
         end},
       {"custom values",
         fun() ->
           meck:expect(autocluster_httpc, get,
-            fun(Scheme, Host, Port, Path, Args) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("consul.node.consul", Host),
               ?assertEqual(8501, Port),
               ?assertEqual([v1, kv, "path", "to", "key"], Path),
               ?assertEqual([{acquire, session_id}], Args),
+              ?assertEqual([], Headers),
+              ?assertEqual([], HttpOpts),
               {ok, []}
             end),
           os:putenv("CONSUL_HOST", "consul.node.consul"),
           os:putenv("CONSUL_PORT", "8501"),
-          ?assertEqual({ok, []}, autocluster_consul:consul_kv_read(["path", "to", "key"], [{acquire, session_id}])),
+          ?assertEqual({ok, []}, autocluster_consul:consul_kv_read(["path", "to", "key"], [{acquire, session_id}], autocluster_consul:maybe_add_acl([]))),
+          ?assert(meck:validate(autocluster_httpc))
+        end},
+      {"default values with token",
+        fun() ->
+          meck:expect(autocluster_httpc, get,
+            fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("localhost", Host),
+              ?assertEqual(8500, Port),
+              ?assertEqual([v1, kv, "path", "to", "key"], Path),
+              ?assertEqual([{acquire, session_id}], Args),
+              ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
+              ?assertEqual([], HttpOpts),
+              {ok, []}
+            end),
+          os:putenv("CONSUL_ACL_TOKEN", "token-value"),
+          ?assertEqual({ok, []}, autocluster_consul:consul_kv_read(["path", "to", "key"], [{acquire, session_id}], autocluster_consul:maybe_add_acl([]))),
+          ?assert(meck:validate(autocluster_httpc))
+        end},
+      {"custom values with token",
+        fun() ->
+          meck:expect(autocluster_httpc, get,
+            fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("consul.node.consul", Host),
+              ?assertEqual(8501, Port),
+              ?assertEqual([v1, kv, "path", "to", "key"], Path),
+              ?assertEqual([{acquire, session_id}], Args),
+              ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
+              ?assertEqual([], HttpOpts),
+              {ok, []}
+            end),
+          os:putenv("CONSUL_HOST", "consul.node.consul"),
+          os:putenv("CONSUL_PORT", "8501"),
+          os:putenv("CONSUL_ACL_TOKEN", "token-value"),
+          ?assertEqual({ok, []}, autocluster_consul:consul_kv_read(["path", "to", "key"], [{acquire, session_id}], autocluster_consul:maybe_add_acl([]))),
           ?assert(meck:validate(autocluster_httpc))
         end}
     ]
@@ -1043,33 +1124,71 @@ consul_kv_write_test_() ->
       {"default values",
         fun() ->
           meck:expect(autocluster_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("localhost", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, kv, "path", "to", "key"], Path),
               ?assertEqual([{acquire, session_id}], Args),
+              ?assertEqual([], Headers),
               ?assertEqual([], Body),
               {ok, []}
             end),
-          ?assertEqual({ok, []}, autocluster_consul:consul_kv_write(["path", "to", "key"], [{acquire, session_id}], [])),
+          ?assertEqual({ok, []}, autocluster_consul:consul_kv_write(["path", "to", "key"], [{acquire, session_id}], autocluster_consul:maybe_add_acl([]), [])),
           ?assert(meck:validate(autocluster_httpc))
         end},
       {"custom values",
         fun() ->
           meck:expect(autocluster_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("consul.node.consul", Host),
               ?assertEqual(8501, Port),
               ?assertEqual([v1, kv, "path", "to", "key"], Path),
               ?assertEqual([{acquire, session_id}], Args),
+              ?assertEqual([], Headers),
               ?assertEqual([], Body),
               {ok, []}
             end),
           os:putenv("CONSUL_HOST", "consul.node.consul"),
           os:putenv("CONSUL_PORT", "8501"),
-          ?assertEqual({ok, []}, autocluster_consul:consul_kv_write(["path", "to", "key"], [{acquire, session_id}], [])),
+          ?assertEqual({ok, []}, autocluster_consul:consul_kv_write(["path", "to", "key"], [{acquire, session_id}], autocluster_consul:maybe_add_acl([]), [])),
+          ?assert(meck:validate(autocluster_httpc))
+        end},
+      {"default values with token",
+        fun() ->
+          meck:expect(autocluster_httpc, put,
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("localhost", Host),
+              ?assertEqual(8500, Port),
+              ?assertEqual([v1, kv, "path", "to", "key"], Path),
+              ?assertEqual([{acquire, session_id}], Args),
+              ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
+              ?assertEqual([], Body),
+              {ok, []}
+            end),
+          os:putenv("CONSUL_ACL_TOKEN", "token-value"),
+          ?assertEqual({ok, []}, autocluster_consul:consul_kv_write(["path", "to", "key"], [{acquire, session_id}], autocluster_consul:maybe_add_acl([]), [])),
+          ?assert(meck:validate(autocluster_httpc))
+        end},
+      {"custom values with token",
+        fun() ->
+          meck:expect(autocluster_httpc, put,
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("consul.node.consul", Host),
+              ?assertEqual(8501, Port),
+              ?assertEqual([v1, kv, "path", "to", "key"], Path),
+              ?assertEqual([{acquire, session_id}], Args),
+              ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
+              ?assertEqual([], Body),
+              {ok, []}
+            end),
+          os:putenv("CONSUL_HOST", "consul.node.consul"),
+          os:putenv("CONSUL_PORT", "8501"),
+          os:putenv("CONSUL_ACL_TOKEN", "token-value"),
+          ?assertEqual({ok, []}, autocluster_consul:consul_kv_write(["path", "to", "key"], [{acquire, session_id}], autocluster_consul:maybe_add_acl([]), [])),
           ?assert(meck:validate(autocluster_httpc))
         end}
     ]
@@ -1088,33 +1207,71 @@ consul_session_create_test_() ->
       {"default values",
         fun() ->
           meck:expect(autocluster_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("localhost", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, session, create], Path),
               ?assertEqual([], Args),
+              ?assertEqual([], Headers),
               ?assertEqual([], Body),
               {ok, []}
             end),
-          ?assertEqual({ok, []}, autocluster_consul:consul_session_create([], [])),
+          ?assertEqual({ok, []}, autocluster_consul:consul_session_create([], autocluster_consul:maybe_add_acl([]), [])),
           ?assert(meck:validate(autocluster_httpc))
         end},
       {"custom values",
         fun() ->
           meck:expect(autocluster_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("consul.node.consul", Host),
               ?assertEqual(8501, Port),
               ?assertEqual([v1, session, create], Path),
               ?assertEqual([], Args),
+              ?assertEqual([], Headers),
               ?assertEqual([], Body),
               {ok, []}
             end),
           os:putenv("CONSUL_HOST", "consul.node.consul"),
           os:putenv("CONSUL_PORT", "8501"),
-          ?assertEqual({ok, []}, autocluster_consul:consul_session_create([], [])),
+          ?assertEqual({ok, []}, autocluster_consul:consul_session_create([], autocluster_consul:maybe_add_acl([]), [])),
+          ?assert(meck:validate(autocluster_httpc))
+        end},
+      {"default values with token",
+        fun() ->
+          meck:expect(autocluster_httpc, put,
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("localhost", Host),
+              ?assertEqual(8500, Port),
+              ?assertEqual([v1, session, create], Path),
+              ?assertEqual([], Args),
+              ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
+              ?assertEqual([], Body),
+              {ok, []}
+            end),
+          os:putenv("CONSUL_ACL_TOKEN", "token-value"),
+          ?assertEqual({ok, []}, autocluster_consul:consul_session_create([], autocluster_consul:maybe_add_acl([]), [])),
+          ?assert(meck:validate(autocluster_httpc))
+        end},
+      {"custom values with token",
+        fun() ->
+          meck:expect(autocluster_httpc, put,
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("consul.node.consul", Host),
+              ?assertEqual(8501, Port),
+              ?assertEqual([v1, session, create], Path),
+              ?assertEqual([], Args),
+              ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
+              ?assertEqual([], Body),
+              {ok, []}
+            end),
+          os:putenv("CONSUL_HOST", "consul.node.consul"),
+          os:putenv("CONSUL_PORT", "8501"),
+          os:putenv("CONSUL_ACL_TOKEN", "token-value"),
+          ?assertEqual({ok, []}, autocluster_consul:consul_session_create([], autocluster_consul:maybe_add_acl([]), [])),
           ?assert(meck:validate(autocluster_httpc))
         end}
     ]
@@ -1133,33 +1290,71 @@ consul_session_renew_test_() ->
       {"default values",
         fun() ->
           meck:expect(autocluster_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("localhost", Host),
               ?assertEqual(8500, Port),
               ?assertEqual([v1, session, renew, session_id], Path),
               ?assertEqual([], Args),
+              ?assertEqual([], Headers),
               ?assertEqual([], Body),
               {ok, []}
             end),
-          ?assertEqual({ok, []}, autocluster_consul:consul_session_renew("session_id", [])),
+          ?assertEqual({ok, []}, autocluster_consul:consul_session_renew("session_id", [], autocluster_consul:maybe_add_acl([]))),
           ?assert(meck:validate(autocluster_httpc))
         end},
       {"custom values",
         fun() ->
           meck:expect(autocluster_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("consul.node.consul", Host),
               ?assertEqual(8501, Port),
               ?assertEqual([v1, session, renew, session_id], Path),
               ?assertEqual([], Args),
+              ?assertEqual([], Headers),
               ?assertEqual([], Body),
               {ok, []}
             end),
           os:putenv("CONSUL_HOST", "consul.node.consul"),
           os:putenv("CONSUL_PORT", "8501"),
-          ?assertEqual({ok, []}, autocluster_consul:consul_session_renew("session_id", [])),
+          ?assertEqual({ok, []}, autocluster_consul:consul_session_renew("session_id", [], autocluster_consul:maybe_add_acl([]))),
+          ?assert(meck:validate(autocluster_httpc))
+        end},
+      {"default values with token",
+        fun() ->
+          meck:expect(autocluster_httpc, put,
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("localhost", Host),
+              ?assertEqual(8500, Port),
+              ?assertEqual([v1, session, renew, session_id], Path),
+              ?assertEqual([], Args),
+              ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
+              ?assertEqual([], Body),
+              {ok, []}
+            end),
+          os:putenv("CONSUL_ACL_TOKEN", "token-value"),
+          ?assertEqual({ok, []}, autocluster_consul:consul_session_renew("session_id", [], autocluster_consul:maybe_add_acl([]))),
+          ?assert(meck:validate(autocluster_httpc))
+        end},
+      {"custom values with token",
+        fun() ->
+          meck:expect(autocluster_httpc, put,
+            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+              ?assertEqual("http", Scheme),
+              ?assertEqual("consul.node.consul", Host),
+              ?assertEqual(8501, Port),
+              ?assertEqual([v1, session, renew, session_id], Path),
+              ?assertEqual([], Args),
+              ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
+              ?assertEqual([], Body),
+              {ok, []}
+            end),
+          os:putenv("CONSUL_HOST", "consul.node.consul"),
+          os:putenv("CONSUL_PORT", "8501"),
+          os:putenv("CONSUL_ACL_TOKEN", "token-value"),
+          ?assertEqual({ok, []}, autocluster_consul:consul_session_renew("session_id", [], autocluster_consul:maybe_add_acl([]))),
           ?assert(meck:validate(autocluster_httpc))
         end}
     ]


### PR DESCRIPTION
## Pass consul token as a header

The recommended way to pass consul tokens is now using headers,
header support was introduced in consul version 0.6.0.

https://www.consul.io/api/index.html#authentication

This change is not compatible with consul versions < 0.6.0

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [X] Cosmetics (whitespace, appearance)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

This change is not compatible with consul versions < 0.6.0