### PR TITLE
Add RBAC example to 'stable' branch

### DIFF
--- a/examples/k8s_rbac_statefulsets/README.md
+++ b/examples/k8s_rbac_statefulsets/README.md
@@ -1,0 +1,67 @@
+RabbitMQ-Autocluster on K8s  [StatefulSet  Controller](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/)   
+
+1. Install [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+
+2. Install [`minikube`](https://kubernetes.io/docs/tasks/tools/install-minikube/)
+
+3. Start `minikube` virtual machine:
+```
+$ minikube start --cpus=2 --memory=2040 --vm-driver=virtualbox
+```
+
+4. Create a namespace only for RabbitMQ test:
+```
+$ kubectl create namespace test-rabbitmq
+```
+
+5. As from Kubernetes 1.6 onwards, RBAC policies are enabled by default, it need deploy the RBAC `YAML` file, regards how to check whether RBAC is enabled or not, pls run `kubectl cluster-info dump | grep authorization-mode`
+```
+$ kubectl create -f examples/k8s_statefulsets/rabbitmq-rbac.yaml
+```
+
+6. Deploy the service `YAML` file:
+```
+$ kubectl create -f examples/k8s_statefulsets/rabbitmq-service.yaml
+```
+
+7. Deploy the RabbitMQ StatefulSet `YAML` file:
+```
+$ kubectl create -f examples/k8s_statefulsets/rabbitmq.yaml
+```
+
+8. Check the cluster status:
+
+Wait  few seconds....then 
+
+```
+$ FIRST_POD=$(kubectl get pods --namespace test-rabbitmq -l 'app=rabbitmq' -o jsonpath='{.items[0].metadata.name }')
+kubectl exec --namespace=test-rabbitmq $FIRST_POD rabbitmqctl cluster_status
+```
+as result you should have:
+```
+Cluster status of node 'rabbit@172.17.0.2'
+[{nodes,[{disc,['rabbit@172.17.0.2','rabbit@172.17.0.4',
+                'rabbit@172.17.0.5']}]},
+ {running_nodes,['rabbit@172.17.0.5','rabbit@172.17.0.4','rabbit@172.17.0.2']},
+ {cluster_name,<<"rabbit@rabbitmq-0.rabbitmq.test-rabbitmq.svc.cluster.local">>},
+ {partitions,[]},
+ {alarms,[{'rabbit@172.17.0.5',[]},
+          {'rabbit@172.17.0.4',[]},
+          {'rabbit@172.17.0.2',[]}]}]
+```
+
+9. Get your `minikube` ip:
+```
+$ minikube ip
+192.168.99.104
+```
+
+10. Ports:
+	* `http://<<minikube_ip>>:31672` - Management UI
+	* `amqp://guest:guest@<<minikube_ip>>:30672` - AMQP
+
+11. Scaling:
+```
+$ kubectl scale statefulset/rabbitmq --namespace=test-rabbitmq --replicas=5
+```
+

--- a/examples/k8s_rbac_statefulsets/rabbitmq-rbac.yaml
+++ b/examples/k8s_rbac_statefulsets/rabbitmq-rbac.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rabbitmq
+  namespace: test-rabbitmq
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rabbitmq
+  namespace: test-rabbitmq
+rules:
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rabbitmq
+  namespace: test-rabbitmq
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rabbitmq
+subjects:
+- kind: ServiceAccount
+  name: rabbitmq
+

--- a/examples/k8s_rbac_statefulsets/rabbitmq-service.yaml
+++ b/examples/k8s_rbac_statefulsets/rabbitmq-service.yaml
@@ -1,0 +1,23 @@
+kind: Service
+apiVersion: v1
+metadata:
+  namespace: test-rabbitmq
+  name: rabbitmq
+  labels:
+    app: rabbitmq
+    type: LoadBalancer  
+spec:
+  type: NodePort
+  ports:
+   - name: http
+     protocol: TCP
+     port: 15672
+     targetPort: 15672
+     nodePort: 31672
+   - name: amqp
+     protocol: TCP
+     port: 5672
+     targetPort: 5672
+     nodePort: 30672
+  selector:
+    app: rabbitmq

--- a/examples/k8s_rbac_statefulsets/rabbitmq.yaml
+++ b/examples/k8s_rbac_statefulsets/rabbitmq.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: rabbitmq
+  namespace: test-rabbitmq
+spec:
+  serviceName: rabbitmq
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      serviceAccountName: rabbitmq
+      terminationGracePeriodSeconds: 10
+      containers:        
+      - name: rabbitmq-autocluster
+        image: pivotalrabbitmq/rabbitmq-autocluster
+        ports:
+          - name: http
+            protocol: TCP
+            containerPort: 15672
+          - name: amqp
+            protocol: TCP
+            containerPort: 5672
+        livenessProbe:
+          exec:
+            command: ["rabbitmqctl", "status"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command: ["rabbitmqctl", "status"]
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+        imagePullPolicy: Always
+        env:
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: RABBITMQ_USE_LONGNAME
+            value: "true"
+          - name: RABBITMQ_NODENAME
+            value: "rabbit@$(MY_POD_IP)"
+          - name: AUTOCLUSTER_TYPE
+            value: "k8s"
+          - name: AUTOCLUSTER_DELAY
+            value: "10"
+          - name: K8S_ADDRESS_TYPE
+            value: "ip" 
+          - name: AUTOCLUSTER_CLEANUP
+            value: "true"
+          - name: CLEANUP_WARN_ONLY
+            value: "false"


### PR DESCRIPTION
## Proposed Changes
Since kubernetes 1.6, RBAC was introduced and kubeadm enabled RBAC by default in the latest releases.
If RBAC is enabled and autocluster backend using k8s,  when autocluster try to find_best_node_to_join, it will access endpoints resource on kubernetes API server, if no corresponding role/rolebinding/serviceaccount exist at this time, the https request will be failed as below:
```
=INFO REPORT==== 14-Nov-2017::10:12:30 ===
autocluster: GET https://kubernetes.default.svc.cluster.local:443/api/v1/namespaces/default/endpoints/rabbitmq

=INFO REPORT==== 14-Nov-2017::10:12:30 ===
autocluster: Response: [{ok,{{"HTTP/1.1",403,"Forbidden"},
                             [{"date","Tue, 14 Nov 2017 10:12:30 GMT"},
                              {"content-length","93"},
                              {"content-type","text/plain"},
                              {"x-content-type-options","nosniff"}],
                             "User \"system:serviceaccount:default:default\" cannot get endpoints in the namespace \"default\"."}}]
```

Below files changed and added to suport RBAC when compared the examples/k8s_statefulsets:

- Created rabbitmq-rbac.yaml to setup new role/rolebinding/serviceaccount for rabbitmq
- Changed README.md(add instruction to apply rabbitmq-rbac.yaml)
- Add "serviceAccountName" in rabbitmq.yaml

## Types of Changes
- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist
- [ x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments
N/A
