### PR TITLE
Log connection errors in nodelist/0 as Erlang terms

### DIFF
--- a/src/autocluster_k8s.erl
+++ b/src/autocluster_k8s.erl
@@ -33,7 +33,7 @@ nodelist() ->
 	    {ok, lists:map(fun node_name/1, Addresses)};
 	{error, Reason} ->
 	    autocluster_log:info(
-	      "Failed to get nodes from k8s - ~s", [Reason]),
+	      "Failed to get nodes from k8s - ~p", [Reason]),
 	    {error, Reason}
     end.
 


### PR DESCRIPTION
These are not strings. See logs in rabbitmq-autocluster #62

